### PR TITLE
feat: add option to use cucumber tags in run command

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -9,22 +9,29 @@ exports.aliases = ['r']
 exports.desc = 'Run Cypress tests'
 
 exports.builder = yargs =>
-    yargs.option('headed', {
-        describe: 'Run in headed mode',
-        type: 'boolean',
-        default: false,
-    })
+    yargs
+        .option('headed', {
+            describe: 'Run in headed mode',
+            type: 'boolean',
+            default: false,
+        })
+        .option('tags', {
+            describe: 'Use cucumber tags',
+            type: 'string',
+            default: '',
+        })
 
 exports.handler = argv => {
     log.info('d2-utils-cypress > run')
 
-    const { headed, port, browser } = argv
+    const { tags, headed, port, browser } = argv
 
     const opts = {
         mode: 'run',
         headless: !headed,
         browser,
         port,
+        tags,
     }
 
     cypress(opts)

--- a/src/tools/cypress.js
+++ b/src/tools/cypress.js
@@ -1,17 +1,18 @@
 const { run } = require('../utils/run.js')
 
-exports.cypress = ({ mode, headless, port, browser, config }) => {
+exports.cypress = ({ mode, headless, port, browser, config, tags }) => {
     const cmd = 'npx'
 
     const modeArgs = mode === 'run' ? [...(headless ? [] : ['--headed'])] : []
 
     const args = [
         '--no-install',
-        'cypress',
+        tags ? 'cypress-tags' : 'cypress',
         mode,
         ...(port ? ['--port', port] : []),
         ...(browser ? ['--browser', browser] : []),
         ...(config ? ['--config', config] : []),
+        ...(tags ? ['--env', `TAGS=${tags}`] : []),
         ...modeArgs,
     ]
 


### PR DESCRIPTION
With this we can do the following:

`npx d2-utils-cypress run --tags "@highlighting and not @skip"`

It's worth mentioning that both features and scenarios can be highlighted.
With the following feature file, only the first scenario will be tested.
All other feature files and the scenarios in this feature file will be ignored:

```feature
@highlighting
Feature: Options can be highlighted

    Scenario: An option is highlighted
        # steps....

    @skip
    Scenario: An option is not highlighted
        # steps....
```

<hr />

In order to try/test this in an existing repo, I had to do this (because `concurrently` doesn't accept parameters that we can pass to one of the commands):

`"cy:run": "concurrently --kill-others --success first -n storybook,cypress 'yarn start:testing' 'wait-on http-get://localhost:5001 && d2-utils-cypress run --tags \"$TAGS\"'",`

and then call it like this:

`TAGS="@highlighting and not @skip" yarn cy:run`