### PR TITLE
feat: add custom data-test selector syntax

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,7 @@
+const dataTestNameToSelector = require('./helper/dataTestNameToSelector')
+const parseSelectorWithDataTest = require('./helper/parseSelectorWithDataTest')
+
+module.exports = {
+    dataTestNameToSelector,
+    parseSelectorWithDataTest,
+}

--- a/helper/dataTestNameToSelector.js
+++ b/helper/dataTestNameToSelector.js
@@ -1,0 +1,17 @@
+/**
+ * @param {string} dataTestName
+ * @param {string} [prefix] - Default to "dhis2-uicore"
+ * @returns {string}
+ */
+const dataTestNameToSelector = (dataTestName, prefix) => {
+    const defaultPrefix = Cypress.env('dhis2_datatest_prefix') || ''
+    // Empty string is a valid value, so check for undefined
+    const actualPrefix = typeof prefix === 'undefined' ? defaultPrefix : prefix
+    const dataTestId = actualPrefix
+        ? `${actualPrefix}-${dataTestName}`
+        : dataTestName
+
+    return `[data-test="${dataTestId}"]`
+}
+
+module.exports = dataTestNameToSelector

--- a/helper/parseSelectorWithDataTest.js
+++ b/helper/parseSelectorWithDataTest.js
@@ -1,0 +1,9 @@
+const dataTestNameToSelector = require('./dataTestNameToSelector')
+
+const parseSelectorWithDataTest = (selector, prefix) => {
+    return selector.replace(/\{([^}]*)\}/g, (match, dataTestName) =>
+        dataTestNameToSelector(dataTestName, prefix)
+    )
+}
+
+export default parseSelectorWithDataTest

--- a/support.js
+++ b/support.js
@@ -1,11 +1,42 @@
-const loginEndPoint = 'dhis-web-commons/security/login.action'
+const parseSelectorWithDataTest = require('./helper/parseSelectorWithDataTest')
+
+/**
+ * Transforms values in curly braces to a data-test selector
+ *
+ * @param {jQuery} subject
+ * @param {string} selectors
+ * @param {string} [prefix]
+ * @returns {Object}
+ */
+/* eslint-disable-next-line max-params */
+const find = (originalFn, subject, selectors, options = {}) => {
+    const { prefix, ...restOptions } = options
+    const selector = parseSelectorWithDataTest(selectors, prefix)
+    return originalFn(subject, selector, restOptions)
+}
+
+/**
+ * Transforms values in curly braces to a data-test selector
+ *
+ * @param {Function} originalFn
+ * @param {string} selectors
+ * @param {Object} [options]
+ * @param {string} [options.prefix]
+ * @returns {Object}
+ */
+const get = (originalFn, selectors, options = {}) => {
+    const { prefix, ...restOptions } = options
+    const selector = parseSelectorWithDataTest(selectors, prefix)
+    return originalFn(selector, restOptions)
+}
 
 /**
  * This is done through cy.request(...)
  * because Cypress doesn't allow multiple domains per test:
  * https://docs.cypress.io/guides/guides/web-security.html#One-Superdomain-per-Test
  */
-Cypress.Commands.add('login', () => {
+const loginEndPoint = 'dhis-web-commons/security/login.action'
+const login = () => {
     const username = Cypress.env('dhis2_username')
     const password = Cypress.env('dhis2_password')
     const loginUrl = Cypress.env('dhis2_base_url')
@@ -21,17 +52,22 @@ Cypress.Commands.add('login', () => {
         },
         headers: { Authorization: loginAuth },
     })
-})
+}
 
-Cypress.Commands.add('stubWithFixture', ({ method = 'GET', url, fixture }) => {
+const stubWithFixture = ({ method = 'GET', url, fixture }) => {
     return cy.route({
         method,
         url,
         response: `fixture:${fixture}`,
     })
-})
+}
 
-Cypress.Commands.add('visitWhenStubbed', (url, options = {}) => {
+/**
+ * @param {string} url
+ * @param {Object} options
+ * @returns {Cypress}
+ */
+const visitWhenStubbed = (url, options = {}) => {
     return cy.visit(url, {
         ...options,
         onBeforeLoad: win => {
@@ -39,4 +75,10 @@ Cypress.Commands.add('visitWhenStubbed', (url, options = {}) => {
             options.onBeforeLoad && options.onBeforeLoad(win)
         },
     })
-})
+}
+
+Cypress.Commands.overwrite('find', find)
+Cypress.Commands.overwrite('get', get)
+Cypress.Commands.add('login', login)
+Cypress.Commands.add('stubWithFixture', stubWithFixture)
+Cypress.Commands.add('visitWhenStubbed', visitWhenStubbed)


### PR DESCRIPTION
This PR will add three things:

## 1. Extend functionality of the `get` and `find` commands

Having to write out the data test selector, especially when using several of them in one query, made the test code look quite bloated and much harder to parse when reading through it.
I've extracted this from the @dhis2/ui-core#639 branch, where I created a substitute syntax for writing selectors with data-test props, so these are all equivalent pairs:

```js
cy.get('[data-test="dhis2-uicore-transfer-sourceoptions"] [data-test="dhis2-uicore-transferoption"]')
cy.get('{transfer-sourceoptions} {transferoption}')

cy.get('[data-test="dhis2-uicore-transfer-filter"] input')
cy.get('{transfer-filter} input')

cy.get('.some-element').find('[data-test="dhis2-uicore-transfer-sourceoptions"] [data-test="dhis2-uicore-transferoption"]')
cy.get('.some-element').find('{transfer-sourceoptions} {transferoption}')

cy.get('.some-element').find('[data-test="dhis2-uicore-transfer"] input')
cy.get('.some-element').find('{transfer} input')

cy.get('[data-test="dhis2-appname-name"] [data-test="dhis2-appname-name2"]')
cy.get('{name} {name2}', { prefix: 'dhis2-appname' })

cy.get('.container [data-test="foobar-name"]')
cy.get('.container {foobar-name}', { prefix: '' })
```

**NOTE:** The original functionality of the two commands is kept in tact

## 2. Prompt the consumer to provide a prefix for the data test prop when installing

The extended `get` and `find` commands use the `dhis2_datatest_prefix` environment variable's value as default value for the prefix. In order to set this value, the install script prompts the user to supply a value. It'll suggest `dhis2-[lib/app-name]` where `lib/app-name` comes from the name in the package.json.

## 3. Expose the helper functions

This can be helpful when trying to get elements that might not exist without cypress to throwing a timeout, like this:

```js
// will yield a jQuery instance with length 0
cy.get('{transfer-pickedoptions}').then($pickedOptions => {
  return $pickedOptions.find(
    dataTestNameToSelector('transferoption')
  )
})
```