### PR TITLE
feat: add concurrently & wait-on command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,19 +30,19 @@
     },
     "dependencies": {
         "@dhis2/cli-helpers-engine": "^1.5.0",
+        "concurrently": "^5.2.0",
         "cross-spawn": "^7.0.1",
         "cypress": "^4.0.2",
         "cypress-cucumber-preprocessor": "^2.0.1",
         "fs-extra": "^8.1.0",
-        "inquirer": "^7.0.4"
+        "inquirer": "^7.0.4",
+        "wait-on": "^4.0.2"
     },
     "publishConfig": {
         "access": "public"
     },
     "devDependencies": {
         "@dhis2/cli-style": "^6.0.0",
-        "@dhis2/cli-utils-docsite": "^1.3.0",
-        "concurrently": "^5.1.0",
-        "wait-on": "^4.0.0"
+        "@dhis2/cli-utils-docsite": "^1.3.0"
     }
 }

--- a/src/commands/common/sharedCLIOptions.js
+++ b/src/commands/common/sharedCLIOptions.js
@@ -1,0 +1,16 @@
+const appStart = {
+    describe: 'Command to start app (disabled with empty string)',
+    type: 'string',
+    default: 'yarn start',
+}
+
+const waitOn = {
+    describe: 'Url to wait for before running cypress',
+    type: 'string',
+    default: 'http-get://localhost:3000',
+}
+
+module.exports = {
+    appStart,
+    waitOn,
+}

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -1,112 +1,17 @@
-const path = require('path')
-const fs = require('fs-extra')
-
-const inquirer = require('inquirer')
-
 const log = require('@dhis2/cli-helpers-engine').reporter
 
+const { createCucumberConfigs } = require('./install/createCucumberConfigs.js')
+const { createCypressConfig } = require('./install/createCypressConfig.js')
 const {
-    CONSUMING_ROOT,
-    CYPRESS_ROOT,
-    CYPRESS_FIXTURES,
-    CYPRESS_INTEGRATION,
-    CYPRESS_PLUGINS,
-    CYPRESS_SUPPORT,
-} = require('../utils/paths.js')
-
-const extractOrgName = moduleName => {
-    const matches = moduleName.match(/^@[^/]+(?=\/)/)
-
-    if (!matches || !matches.length) {
-        return 'dhis2'
-    }
-
-    const [orgNameWithAtSymbol] = matches
-    return orgNameWithAtSymbol.replace('@', '')
-}
-
-const extractAppName = moduleName => {
-    const matches = moduleName.match(/^@[^/]+\/(.+)$/)
-    const appName = matches && matches.length > 1 ? matches[1] : moduleName
-
-    return appName
-        .replace(/-app$/, '') // dhis2 apps' names end with "app"
-        .replace(/\W/g, '')
-}
-
-const readJson = filename => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
-    const exists = fs.existsSync(filepath)
-
-    if (!exists) {
-        log.warn(`File: '${filename}' does not exist`)
-        return
-    }
-
-    let content
-    try {
-        content = JSON.parse(fs.readFileSync(filepath))
-    } catch (e) {
-        log.error(`Could not parse contents of file: '${filename}'`)
-        return
-    }
-
-    return content
-}
-
-const addToJson = (filename, data, overwrite = false) => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
-    const exists = fs.existsSync(filepath)
-
-    if (!exists) {
-        log.warn(`File: '${filename}' does not exist`)
-        return
-    }
-
-    if (overwrite) {
-        return write(filename, data, true)
-    }
-
-    const existingData = readJson(filename)
-    return write(filename, { ...existingData, ...data }, true)
-}
-
-const write = (filename, data, overwrite) => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
-    const exists = fs.existsSync(filepath)
-    const content = JSON.stringify(data, null, 4)
-
-    if (exists && !overwrite) {
-        log.warn(`Existing file: '${filename}', use --force to overwrite.`)
-        return
-    }
-
-    fs.writeFileSync(filepath, content, { encoding: 'utf8' })
-}
-
-function copy(from, to, overwrite = true) {
-    try {
-        const exists = fs.existsSync(to)
-        const empty = exists ? fs.statSync(to).size === 0 : false
-
-        const replace = empty ? true : overwrite
-
-        if (exists && !replace) {
-            log.print(`Skip existing: ${path.relative(process.cwd(), to)}`)
-        } else {
-            log.print(`Installing: ${path.relative(process.cwd(), to)}`)
-        }
-        fs.ensureDirSync(path.dirname(to))
-        fs.copySync(from, to, { overwrite: replace })
-    } catch (err) {
-        log.error(`Failed to install configuration file: ${to}`, err)
-    }
-}
+    createCypressEnvConfig,
+} = require('./install/createCypressEnvConfig.js')
+const {
+    createCypressSupportFile,
+} = require('./install/createCypressSupportFile.js')
+const { ensureDirectories } = require('./install/ensureDirectories.js')
 
 exports.command = 'install'
-
 exports.aliases = ['i']
-
 exports.desc = 'Install DHIS2 Cypress configuration into project'
 
 exports.builder = yargs =>
@@ -140,153 +45,25 @@ exports.builder = yargs =>
 exports.handler = async argv => {
     log.info('d2-utils-cypress > install')
 
-    const { force, cypressConfig, cypressEnv, cucumber, support } = argv
-
-    const prompt = inquirer.createPromptModule()
-
     try {
-        if (cypressConfig) {
-            const cypressAnswers = await prompt([
-                {
-                    type: 'input',
-                    name: 'baseUrl',
-                    message: 'URL that Cypress should run tests against:',
-                    default: 'http://localhost:3000',
-                },
-                {
-                    type: 'input',
-                    name: 'testFiles',
-                    message: 'Glob pattern for the test files to run:',
-                    default: '**/*.feature',
-                },
-                {
-                    type: 'confirm',
-                    name: 'video',
-                    message: 'Record video?',
-                    default: false,
-                },
-                {
-                    type: 'input',
-                    name: 'projectId',
-                    message: 'The unique Cypress project ID:',
-                },
-            ])
+        const { force, cypressConfig, cypressEnv, cucumber, support } = argv
 
-            write(
-                'cypress.json',
-                {
-                    baseUrl: cypressAnswers.baseUrl,
-                    testFiles: cypressAnswers.testFiles,
-                    video: cypressAnswers.video,
-                    ...(cypressAnswers.projectId
-                        ? [cypressAnswers.projectId]
-                        : []),
-                },
-                force
-            )
+        ensureDirectories()
+
+        if (cypressConfig) {
+            await createCypressConfig(force)
         }
 
         if (cypressEnv) {
-            const envAnswers = await prompt([
-                {
-                    type: 'input',
-                    name: 'dhis2Url',
-                    message: 'The DHIS2 instance URL to use as backend:',
-                    default: 'http://localhost:8080',
-                },
-                {
-                    type: 'input',
-                    name: 'username',
-                    message: 'DHIS2 Username:',
-                    default: 'admin',
-                },
-                {
-                    type: 'input',
-                    name: 'password',
-                    message: 'DHIS2 Username password:',
-                    default: 'district',
-                },
-            ])
-
-            write(
-                'cypress.env.json',
-                {
-                    dhis2_base_url: envAnswers.dhis2Url,
-                    dhis2_username: envAnswers.username,
-                    dhis2_password: envAnswers.password,
-                },
-                force
-            )
-
-            log.info(
-                'Make sure to add `cypress.env.json` to the `.gitignore` file!'
-            )
+            await createCypressEnvConfig(force)
         }
 
-        fs.ensureDirSync(CYPRESS_ROOT)
-        fs.ensureDirSync(CYPRESS_FIXTURES)
-        fs.ensureDirSync(CYPRESS_INTEGRATION)
-        fs.ensureDirSync(CYPRESS_PLUGINS)
-        fs.ensureDirSync(CYPRESS_SUPPORT)
-
         if (cucumber) {
-            const cucFrom = path.join(
-                __dirname,
-                '..',
-                '..',
-                'templates',
-                'plugins.js'
-            )
-            const cucTo = path.join(CYPRESS_PLUGINS, 'index.js')
-            copy(cucFrom, cucTo, force)
-
-            const cucConfFrom = path.join(
-                __dirname,
-                '..',
-                '..',
-                'templates',
-                'cucumber-config.js'
-            )
-            const cucConfTo = path.join(
-                CONSUMING_ROOT,
-                'cypress-cucumber-preprocessor.config.js'
-            )
-            copy(cucConfFrom, cucConfTo, force)
+            createCucumberConfigs(force)
         }
 
         if (support) {
-            const supFrom = path.join(
-                __dirname,
-                '..',
-                '..',
-                'templates',
-                'support.js'
-            )
-            const supTo = path.join(CYPRESS_SUPPORT, 'index.js')
-            copy(supFrom, supTo, force)
-
-            const packageJson = readJson('package.json')
-            const moduleName = packageJson ? packageJson.name : ''
-            const orgName = extractOrgName(moduleName)
-            const appName = extractAppName(moduleName)
-            const prefixDefault = [
-                ...(orgName ? [orgName] : []),
-                ...(appName ? [appName] : []),
-            ].join('-')
-
-            const envAnswers = await prompt([
-                {
-                    type: 'input',
-                    name: 'dhis2DatatestPrefix',
-                    message:
-                        'The prefix for the cy.get data-test attributes of the app (e. g. "dhis2-appname-"):',
-                    ...(prefixDefault ? { default: prefixDefault } : {}),
-                },
-            ])
-
-            addToJson('cypress.env.json', {
-                dhis2_datatest_prefix: envAnswers.dhis2DatatestPrefix,
-            })
+            await createCypressSupportFile(force)
         }
     } catch (e) {
         log.error(e)

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -59,7 +59,7 @@ exports.handler = async argv => {
         }
 
         if (cucumber) {
-            createCucumberConfigs(force)
+            await createCucumberConfigs(force)
         }
 
         if (support) {

--- a/src/commands/install/createCucumberConfigs.js
+++ b/src/commands/install/createCucumberConfigs.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const { CONSUMING_ROOT, CYPRESS_PLUGINS } = require('../../utils/paths.js')
+const { copy } = require('../../utils/fs.js')
+
+const TEMPLATE_PATH = path.join(__dirname, '../../../templates')
+
+const PLUGIN_TEMPLATE_SOURCE = path.join(TEMPLATE_PATH, 'plugins.js')
+const PLUGIN_TEMPLATE_DESTINATION = path.join(CYPRESS_PLUGINS, 'index.js')
+
+const CONFIG_TEMPLATE_SOURCE = path.join(TEMPLATE_PATH, 'plugins.js')
+const CONFIG_TEMPLATE_DESTINATION = path.join(
+    CONSUMING_ROOT,
+    'cypress-cucumber-preprocessor.config.js'
+)
+
+const createCucumberConfigs = force => {
+    copy(PLUGIN_TEMPLATE_SOURCE, PLUGIN_TEMPLATE_DESTINATION, force)
+    copy(CONFIG_TEMPLATE_SOURCE, CONFIG_TEMPLATE_DESTINATION, force)
+}
+
+module.exports = { createCucumberConfigs }

--- a/src/commands/install/createCucumberConfigs.js
+++ b/src/commands/install/createCucumberConfigs.js
@@ -1,21 +1,39 @@
-const path = require('path')
-const { CONSUMING_ROOT, CYPRESS_PLUGINS } = require('../../utils/paths.js')
+const inquirer = require('inquirer')
+const { addToJson } = require('../../utils/fs.js')
 const { copy } = require('../../utils/fs.js')
+const {
+    CYPRESS_CONFIG_PATH,
+    CUCUMBER_PLUGIN_TEMPLATE_SOURCE,
+    CUCUMBER_PLUGIN_TEMPLATE_DESTINATION,
+    CUCUMBER_CONFIG_TEMPLATE_SOURCE,
+    CUCUMBER_CONFIG_TEMPLATE_DESTINATION,
+} = require('../../utils/paths.js')
 
-const TEMPLATE_PATH = path.join(__dirname, '../../../templates')
+const createCucumberConfigs = async force => {
+    const prompt = inquirer.createPromptModule()
 
-const PLUGIN_TEMPLATE_SOURCE = path.join(TEMPLATE_PATH, 'plugins.js')
-const PLUGIN_TEMPLATE_DESTINATION = path.join(CYPRESS_PLUGINS, 'index.js')
+    copy(
+        CUCUMBER_PLUGIN_TEMPLATE_SOURCE,
+        CUCUMBER_PLUGIN_TEMPLATE_DESTINATION,
+        force
+    )
 
-const CONFIG_TEMPLATE_SOURCE = path.join(TEMPLATE_PATH, 'plugins.js')
-const CONFIG_TEMPLATE_DESTINATION = path.join(
-    CONSUMING_ROOT,
-    'cypress-cucumber-preprocessor.config.js'
-)
+    copy(
+        CUCUMBER_CONFIG_TEMPLATE_SOURCE,
+        CUCUMBER_CONFIG_TEMPLATE_DESTINATION,
+        force
+    )
 
-const createCucumberConfigs = force => {
-    copy(PLUGIN_TEMPLATE_SOURCE, PLUGIN_TEMPLATE_DESTINATION, force)
-    copy(CONFIG_TEMPLATE_SOURCE, CONFIG_TEMPLATE_DESTINATION, force)
+    const { testFiles } = await prompt([
+        {
+            type: 'input',
+            name: 'testFiles',
+            message: 'Glob pattern for the test files to run:',
+            default: '**/*.feature',
+        },
+    ])
+
+    addToJson(CYPRESS_CONFIG_PATH, { testFiles })
 }
 
 module.exports = { createCucumberConfigs }

--- a/src/commands/install/createCypressConfig.js
+++ b/src/commands/install/createCypressConfig.js
@@ -30,7 +30,9 @@ const createCypressConfig = async force => {
         {
             baseUrl: cypressAnswers.baseUrl,
             video: cypressAnswers.video,
-            ...(cypressAnswers.projectId ? [cypressAnswers.projectId] : []),
+            ...(cypressAnswers.projectId
+                ? { projectId: cypressAnswers.projectId }
+                : {}),
         },
         force
     )

--- a/src/commands/install/createCypressConfig.js
+++ b/src/commands/install/createCypressConfig.js
@@ -1,6 +1,6 @@
 const inquirer = require('inquirer')
-
 const { write } = require('../../utils/fs.js')
+const { CYPRESS_CONFIG_PATH } = require('../../utils/paths.js')
 
 const createCypressConfig = async force => {
     const prompt = inquirer.createPromptModule()
@@ -11,12 +11,6 @@ const createCypressConfig = async force => {
             name: 'baseUrl',
             message: 'URL that Cypress should run tests against:',
             default: 'http://localhost:3000',
-        },
-        {
-            type: 'input',
-            name: 'testFiles',
-            message: 'Glob pattern for the test files to run:',
-            default: '**/*.feature',
         },
         {
             type: 'confirm',
@@ -32,10 +26,9 @@ const createCypressConfig = async force => {
     ])
 
     write(
-        'cypress.json',
+        CYPRESS_CONFIG_PATH,
         {
             baseUrl: cypressAnswers.baseUrl,
-            testFiles: cypressAnswers.testFiles,
             video: cypressAnswers.video,
             ...(cypressAnswers.projectId ? [cypressAnswers.projectId] : []),
         },

--- a/src/commands/install/createCypressConfig.js
+++ b/src/commands/install/createCypressConfig.js
@@ -1,0 +1,46 @@
+const inquirer = require('inquirer')
+
+const { write } = require('../../utils/fs.js')
+
+const createCypressConfig = async force => {
+    const prompt = inquirer.createPromptModule()
+
+    const cypressAnswers = await prompt([
+        {
+            type: 'input',
+            name: 'baseUrl',
+            message: 'URL that Cypress should run tests against:',
+            default: 'http://localhost:3000',
+        },
+        {
+            type: 'input',
+            name: 'testFiles',
+            message: 'Glob pattern for the test files to run:',
+            default: '**/*.feature',
+        },
+        {
+            type: 'confirm',
+            name: 'video',
+            message: 'Record video?',
+            default: false,
+        },
+        {
+            type: 'input',
+            name: 'projectId',
+            message: 'The unique Cypress project ID:',
+        },
+    ])
+
+    write(
+        'cypress.json',
+        {
+            baseUrl: cypressAnswers.baseUrl,
+            testFiles: cypressAnswers.testFiles,
+            video: cypressAnswers.video,
+            ...(cypressAnswers.projectId ? [cypressAnswers.projectId] : []),
+        },
+        force
+    )
+}
+
+module.exports = { createCypressConfig }

--- a/src/commands/install/createCypressEnvConfig.js
+++ b/src/commands/install/createCypressEnvConfig.js
@@ -1,0 +1,43 @@
+const log = require('@dhis2/cli-helpers-engine').reporter
+const inquirer = require('inquirer')
+
+const { write } = require('../../utils/fs.js')
+
+const createCypressEnvConfig = async force => {
+    const prompt = inquirer.createPromptModule()
+
+    const envAnswers = await prompt([
+        {
+            type: 'input',
+            name: 'dhis2Url',
+            message: 'The DHIS2 instance URL to use as backend:',
+            default: 'http://localhost:8080',
+        },
+        {
+            type: 'input',
+            name: 'username',
+            message: 'DHIS2 Username:',
+            default: 'admin',
+        },
+        {
+            type: 'input',
+            name: 'password',
+            message: 'DHIS2 Username password:',
+            default: 'district',
+        },
+    ])
+
+    write(
+        'cypress.env.json',
+        {
+            dhis2_base_url: envAnswers.dhis2Url,
+            dhis2_username: envAnswers.username,
+            dhis2_password: envAnswers.password,
+        },
+        force
+    )
+
+    log.info('Make sure to add `cypress.env.json` to the `.gitignore` file!')
+}
+
+module.exports = { createCypressEnvConfig }

--- a/src/commands/install/createCypressEnvConfig.js
+++ b/src/commands/install/createCypressEnvConfig.js
@@ -2,6 +2,7 @@ const log = require('@dhis2/cli-helpers-engine').reporter
 const inquirer = require('inquirer')
 
 const { write } = require('../../utils/fs.js')
+const { CYPRESS_CONFIG_ENV_PATH } = require('../../utils/paths.js')
 
 const createCypressEnvConfig = async force => {
     const prompt = inquirer.createPromptModule()
@@ -28,7 +29,7 @@ const createCypressEnvConfig = async force => {
     ])
 
     write(
-        'cypress.env.json',
+        CYPRESS_CONFIG_ENV_PATH,
         {
             dhis2_base_url: envAnswers.dhis2Url,
             dhis2_username: envAnswers.username,

--- a/src/commands/install/createCypressSupportFile.js
+++ b/src/commands/install/createCypressSupportFile.js
@@ -1,12 +1,11 @@
-const path = require('path')
 const inquirer = require('inquirer')
-
-const { CYPRESS_SUPPORT } = require('../../utils/paths.js')
 const { addToJson, copy, readJson } = require('../../utils/fs.js')
-
-const TEMPLATE_PATH = path.join(__dirname, '../../../templates')
-const SUPPORT_FILE_SOURCE = path.join(TEMPLATE_PATH, 'support.js')
-const SUPPORT_FILE_DESTINATION = path.join(CYPRESS_SUPPORT, 'index.js')
+const {
+    PACKAGE_JSON,
+    CYPRESS_CONFIG_ENV_PATH,
+    CYPRESS_SUPPORT_FILE_SOURCE,
+    CYPRESS_SUPPORT_FILE_DESTINATION,
+} = require('../../utils/paths.js')
 
 const extractOrgName = moduleName => {
     const matches = moduleName.match(/^@[^/]+(?=\/)/)
@@ -30,9 +29,9 @@ const extractAppName = moduleName => {
 
 const createCypressSupportFile = async force => {
     const prompt = inquirer.createPromptModule()
-    copy(SUPPORT_FILE_SOURCE, SUPPORT_FILE_DESTINATION, force)
+    copy(CYPRESS_SUPPORT_FILE_SOURCE, CYPRESS_SUPPORT_FILE_DESTINATION, force)
 
-    const packageJson = readJson('package.json')
+    const packageJson = readJson(PACKAGE_JSON)
     const moduleName = packageJson ? packageJson.name : ''
     const orgName = extractOrgName(moduleName)
     const appName = extractAppName(moduleName)
@@ -51,7 +50,7 @@ const createCypressSupportFile = async force => {
         },
     ])
 
-    addToJson('cypress.env.json', {
+    addToJson(CYPRESS_CONFIG_ENV_PATH, {
         dhis2_datatest_prefix: envAnswers.dhis2DatatestPrefix,
     })
 }

--- a/src/commands/install/createCypressSupportFile.js
+++ b/src/commands/install/createCypressSupportFile.js
@@ -1,0 +1,59 @@
+const path = require('path')
+const inquirer = require('inquirer')
+
+const { CYPRESS_SUPPORT } = require('../../utils/paths.js')
+const { addToJson, copy, readJson } = require('../../utils/fs.js')
+
+const TEMPLATE_PATH = path.join(__dirname, '../../../templates')
+const SUPPORT_FILE_SOURCE = path.join(TEMPLATE_PATH, 'support.js')
+const SUPPORT_FILE_DESTINATION = path.join(CYPRESS_SUPPORT, 'index.js')
+
+const extractOrgName = moduleName => {
+    const matches = moduleName.match(/^@[^/]+(?=\/)/)
+
+    if (!matches || !matches.length) {
+        return 'dhis2'
+    }
+
+    const [orgNameWithAtSymbol] = matches
+    return orgNameWithAtSymbol.replace('@', '')
+}
+
+const extractAppName = moduleName => {
+    const matches = moduleName.match(/^@[^/]+\/(.+)$/)
+    const appName = matches && matches.length > 1 ? matches[1] : moduleName
+
+    return appName
+        .replace(/-app$/, '') // dhis2 apps' names end with "app"
+        .replace(/\W/g, '')
+}
+
+const createCypressSupportFile = async force => {
+    const prompt = inquirer.createPromptModule()
+    copy(SUPPORT_FILE_SOURCE, SUPPORT_FILE_DESTINATION, force)
+
+    const packageJson = readJson('package.json')
+    const moduleName = packageJson ? packageJson.name : ''
+    const orgName = extractOrgName(moduleName)
+    const appName = extractAppName(moduleName)
+    const prefixDefault = [
+        ...(orgName ? [orgName] : []),
+        ...(appName ? [appName] : []),
+    ].join('-')
+
+    const envAnswers = await prompt([
+        {
+            type: 'input',
+            name: 'dhis2DatatestPrefix',
+            message:
+                'The prefix for the cy.get data-test attributes of the app (e. g. "dhis2-appname-"):',
+            ...(prefixDefault ? { default: prefixDefault } : {}),
+        },
+    ])
+
+    addToJson('cypress.env.json', {
+        dhis2_datatest_prefix: envAnswers.dhis2DatatestPrefix,
+    })
+}
+
+module.exports = { createCypressSupportFile }

--- a/src/commands/install/ensureDirectories.js
+++ b/src/commands/install/ensureDirectories.js
@@ -1,0 +1,18 @@
+const fs = require('fs-extra')
+const {
+    CYPRESS_ROOT,
+    CYPRESS_FIXTURES,
+    CYPRESS_INTEGRATION,
+    CYPRESS_PLUGINS,
+    CYPRESS_SUPPORT,
+} = require('../../utils/paths.js')
+
+const ensureDirectories = () => {
+    fs.ensureDirSync(CYPRESS_ROOT)
+    fs.ensureDirSync(CYPRESS_FIXTURES)
+    fs.ensureDirSync(CYPRESS_INTEGRATION)
+    fs.ensureDirSync(CYPRESS_PLUGINS)
+    fs.ensureDirSync(CYPRESS_SUPPORT)
+}
+
+module.exports = { ensureDirectories }

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,42 +1,17 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
-const concurrently = require('concurrently')
-const { cypress } = require('../tools/cypress.js')
+const { execCypress } = require('../tools/execCypress.js')
 const { appStart, waitOn } = require('./common/sharedCLIOptions.js')
 
 exports.command = 'open'
-
 exports.aliases = ['o']
-
 exports.desc = 'Open Cypress UI'
-
 exports.builder = yargs =>
     yargs.option('appStart', appStart).option('waitOn', waitOn)
 
 exports.handler = argv => {
-    log.info('d2-utils-cypress > open')
     const { appStart, port, browser, waitOn } = argv
+    const cypressOptions = { mode: 'open', browser, port }
 
-    const opts = {
-        mode: 'open',
-        browser,
-        port,
-    }
-
-    if (!appStart) {
-        log.info('"appStart" empty. Running cypress directly')
-
-        cypress(opts)
-    } else {
-        const cypressCommand = cypress({ ...opts, exec: false })
-        const waitOnCommand = `npx --no-install wait-on ${waitOn}`
-        const waitAndCypress = [waitOnCommand, cypressCommand].join(' && ')
-
-        concurrently(
-            [
-                { command: appStart, name: 'app' },
-                { command: waitAndCypress, name: 'cypress' },
-            ],
-            { kill: ['success'] }
-        )
-    }
+    log.info('d2-utils-cypress > open')
+    execCypress({ appStart, waitOn, cypressOptions })
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,6 +1,7 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
-
+const concurrently = require('concurrently')
 const { cypress } = require('../tools/cypress.js')
+const { appStart, waitOn } = require('./common/sharedCLIOptions.js')
 
 exports.command = 'run'
 
@@ -9,16 +10,19 @@ exports.aliases = ['r']
 exports.desc = 'Run Cypress tests'
 
 exports.builder = yargs =>
-    yargs.option('headed', {
-        describe: 'Run in headed mode',
-        type: 'boolean',
-        default: false,
-    })
+    yargs
+        .option('headed', {
+            describe: 'Run in headed mode',
+            type: 'boolean',
+            default: false,
+        })
+        .option('appStart', appStart)
+        .option('waitOn', waitOn)
 
 exports.handler = argv => {
     log.info('d2-utils-cypress > run')
 
-    const { headed, port, browser } = argv
+    const { appStart, headed, port, browser, waitOn } = argv
 
     const opts = {
         mode: 'run',
@@ -27,5 +31,21 @@ exports.handler = argv => {
         port,
     }
 
-    cypress(opts)
+    if (!appStart) {
+        log.info('"appStart" empty. Running cypress directly')
+
+        cypress(opts)
+    } else {
+        const cypressCommand = cypress({ ...opts, exec: false })
+        const waitOnCommand = `npx --no-install wait-on ${waitOn}`
+        const waitAndCypress = [waitOnCommand, cypressCommand].join(' && ')
+
+        concurrently(
+            [
+                { command: appStart, name: 'app' },
+                { command: waitAndCypress, name: 'cypress' },
+            ],
+            { kill: ['success'] }
+        )
+    }
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,14 +1,10 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
-const concurrently = require('concurrently')
-const { cypress } = require('../tools/cypress.js')
+const { execCypress } = require('../tools/execCypress.js')
 const { appStart, waitOn } = require('./common/sharedCLIOptions.js')
 
 exports.command = 'run'
-
 exports.aliases = ['r']
-
 exports.desc = 'Run Cypress tests'
-
 exports.builder = yargs =>
     yargs
         .option('headed', {
@@ -20,32 +16,9 @@ exports.builder = yargs =>
         .option('waitOn', waitOn)
 
 exports.handler = argv => {
-    log.info('d2-utils-cypress > run')
-
     const { appStart, headed, port, browser, waitOn } = argv
+    const cypressOptions = { mode: 'run', headless: !headed, browser, port }
 
-    const opts = {
-        mode: 'run',
-        headless: !headed,
-        browser,
-        port,
-    }
-
-    if (!appStart) {
-        log.info('"appStart" empty. Running cypress directly')
-
-        cypress(opts)
-    } else {
-        const cypressCommand = cypress({ ...opts, exec: false })
-        const waitOnCommand = `npx --no-install wait-on ${waitOn}`
-        const waitAndCypress = [waitOnCommand, cypressCommand].join(' && ')
-
-        concurrently(
-            [
-                { command: appStart, name: 'app' },
-                { command: waitAndCypress, name: 'cypress' },
-            ],
-            { kill: ['success'] }
-        )
-    }
+    log.info('d2-utils-cypress > run')
+    execCypress({ appStart, waitOn, cypressOptions })
 }

--- a/src/tools/cypress.js
+++ b/src/tools/cypress.js
@@ -1,6 +1,6 @@
 const { run } = require('../utils/run.js')
 
-exports.cypress = ({ mode, headless, port, browser, config }) => {
+exports.cypress = ({ mode, headless, port, browser, config, exec = true }) => {
     const cmd = 'npx'
 
     const modeArgs = mode === 'run' ? [...(headless ? [] : ['--headed'])] : []
@@ -15,6 +15,10 @@ exports.cypress = ({ mode, headless, port, browser, config }) => {
         ...modeArgs,
     ]
 
-    console.log(process.cwd())
-    run(cmd, { args })
+    if (exec) {
+        console.log(process.cwd())
+        return run(cmd, { args })
+    }
+
+    return [cmd, ...args].join(' ')
 }

--- a/src/tools/execCypress.js
+++ b/src/tools/execCypress.js
@@ -1,0 +1,15 @@
+const log = require('@dhis2/cli-helpers-engine').reporter
+const { run } = require('../utils/run.js')
+const { getCypressCommand } = require('./getCypressCommand.js')
+const { waitOnAndCypress } = require('./waitOnAndCypress.js')
+
+exports.execCypress = ({ appStart, waitOn, cypressOptions }) => {
+    if (!appStart) {
+        const { cmd, options } = getCypressCommand(cypressOptions)
+
+        log.info('"appStart" empty. Running cypress directly')
+        run(cmd, options)
+    } else {
+        waitOnAndCypress({ appStart, waitOn, cypressOptions })
+    }
+}

--- a/src/tools/getCypressCommand.js
+++ b/src/tools/getCypressCommand.js
@@ -1,6 +1,4 @@
-const { run } = require('../utils/run.js')
-
-exports.cypress = ({ mode, headless, port, browser, config, exec = true }) => {
+exports.getCypressCommand = ({ mode, headless, port, browser, config }) => {
     const cmd = 'npx'
 
     const modeArgs = mode === 'run' ? [...(headless ? [] : ['--headed'])] : []
@@ -15,10 +13,6 @@ exports.cypress = ({ mode, headless, port, browser, config, exec = true }) => {
         ...modeArgs,
     ]
 
-    if (exec) {
-        console.log(process.cwd())
-        return run(cmd, { args })
-    }
-
-    return [cmd, ...args].join(' ')
+    const options = { args }
+    return { cmd, options }
 }

--- a/src/tools/waitOnAndCypress.js
+++ b/src/tools/waitOnAndCypress.js
@@ -1,0 +1,17 @@
+const { getCypressCommand } = require('./getCypressCommand.js')
+const concurrently = require('concurrently')
+
+exports.waitOnAndCypress = ({ appStart, waitOn, cypressOptions }) => {
+    const { cmd, options } = getCypressCommand(cypressOptions)
+    const cypressCommand = [cmd, ...options.args].join(' ')
+    const waitOnCommand = `npx --no-install wait-on ${waitOn}`
+    const waitAndCypress = `${waitOnCommand} && ${cypressCommand}`
+
+    concurrently(
+        [
+            { command: appStart, name: 'app' },
+            { command: waitAndCypress, name: 'cypress' },
+        ],
+        { kill: ['success'] }
+    )
+}

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -1,0 +1,81 @@
+const fs = require('fs-extra')
+const path = require('path')
+const log = require('@dhis2/cli-helpers-engine').reporter
+
+const { CONSUMING_ROOT } = require('./paths.js')
+
+const readJson = filename => {
+    const filepath = path.join(CONSUMING_ROOT, filename)
+    const exists = fs.existsSync(filepath)
+
+    if (!exists) {
+        log.warn(`File: '${filename}' does not exist`)
+        return
+    }
+
+    let content
+    try {
+        content = JSON.parse(fs.readFileSync(filepath))
+    } catch (e) {
+        log.error(`Could not parse contents of file: '${filename}'`)
+        return
+    }
+
+    return content
+}
+
+const addToJson = (filename, data, overwrite = false) => {
+    const filepath = path.join(CONSUMING_ROOT, filename)
+    const exists = fs.existsSync(filepath)
+
+    if (!exists) {
+        log.warn(`File: '${filename}' does not exist`)
+        return
+    }
+
+    if (overwrite) {
+        return write(filename, data, true)
+    }
+
+    const existingData = readJson(filename)
+    return write(filename, { ...existingData, ...data }, true)
+}
+
+const write = (filename, data, overwrite) => {
+    const filepath = path.join(CONSUMING_ROOT, filename)
+    const exists = fs.existsSync(filepath)
+    const content = JSON.stringify(data, null, 4)
+
+    if (exists && !overwrite) {
+        log.warn(`Existing file: '${filename}', use --force to overwrite.`)
+        return
+    }
+
+    fs.writeFileSync(filepath, content, { encoding: 'utf8' })
+}
+
+function copy(from, to, overwrite = true) {
+    try {
+        const exists = fs.existsSync(to)
+        const empty = exists ? fs.statSync(to).size === 0 : false
+
+        const replace = empty ? true : overwrite
+
+        if (exists && !replace) {
+            log.print(`Skip existing: ${path.relative(process.cwd(), to)}`)
+        } else {
+            log.print(`Installing: ${path.relative(process.cwd(), to)}`)
+        }
+        fs.ensureDirSync(path.dirname(to))
+        fs.copySync(from, to, { overwrite: replace })
+    } catch (err) {
+        log.error(`Failed to install configuration file: ${to}`, err)
+    }
+}
+
+module.exports = {
+    readJson,
+    addToJson,
+    write,
+    copy,
+}

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -2,14 +2,11 @@ const fs = require('fs-extra')
 const path = require('path')
 const log = require('@dhis2/cli-helpers-engine').reporter
 
-const { CONSUMING_ROOT } = require('./paths.js')
-
-const readJson = filename => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
+const readJson = filepath => {
     const exists = fs.existsSync(filepath)
 
     if (!exists) {
-        log.warn(`File: '${filename}' does not exist`)
+        log.warn(`File: '${filepath}' does not exist`)
         return
     }
 
@@ -17,37 +14,35 @@ const readJson = filename => {
     try {
         content = JSON.parse(fs.readFileSync(filepath))
     } catch (e) {
-        log.error(`Could not parse contents of file: '${filename}'`)
+        log.error(`Could not parse contents of file: '${filepath}'`)
         return
     }
 
     return content
 }
 
-const addToJson = (filename, data, overwrite = false) => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
+const addToJson = (filepath, data, overwrite = false) => {
     const exists = fs.existsSync(filepath)
 
     if (!exists) {
-        log.warn(`File: '${filename}' does not exist`)
+        log.warn(`File: '${filepath}' does not exist`)
         return
     }
 
     if (overwrite) {
-        return write(filename, data, true)
+        return write(filepath, data, true)
     }
 
-    const existingData = readJson(filename)
-    return write(filename, { ...existingData, ...data }, true)
+    const existingData = readJson(filepath)
+    return write(filepath, { ...existingData, ...data }, true)
 }
 
-const write = (filename, data, overwrite) => {
-    const filepath = path.join(CONSUMING_ROOT, filename)
+const write = (filepath, data, overwrite) => {
     const exists = fs.existsSync(filepath)
     const content = JSON.stringify(data, null, 4)
 
     if (exists && !overwrite) {
-        log.warn(`Existing file: '${filename}', use --force to overwrite.`)
+        log.warn(`Existing file: '${filepath}', use --force to overwrite.`)
         return
     }
 

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,19 +1,47 @@
 const path = require('path')
 
 const CONSUMING_ROOT = path.join(process.cwd())
+const PACKAGE_JSON = path.join(CONSUMING_ROOT, 'package.json')
+const TEMPLATES = path.join(__dirname, '../../templates')
 
 const CYPRESS_ROOT = path.join(CONSUMING_ROOT, 'cypress')
-
 const CYPRESS_FIXTURES = path.join(CYPRESS_ROOT, 'fixtures')
 const CYPRESS_INTEGRATION = path.join(CYPRESS_ROOT, 'integration')
 const CYPRESS_PLUGINS = path.join(CYPRESS_ROOT, 'plugins')
 const CYPRESS_SUPPORT = path.join(CYPRESS_ROOT, 'support')
+const CYPRESS_CONFIG_PATH = path.join(CONSUMING_ROOT, 'cypress.json')
+const CYPRESS_CONFIG_ENV_PATH = path.join(CONSUMING_ROOT, 'cypress.env.json')
+const CYPRESS_SUPPORT_FILE_SOURCE = path.join(TEMPLATES, 'support.js')
+const CYPRESS_SUPPORT_FILE_DESTINATION = path.join(CYPRESS_SUPPORT, 'index.js')
+
+const CUCUMBER_PLUGIN_TEMPLATE_SOURCE = path.join(TEMPLATES, 'plugins.js')
+const CUCUMBER_PLUGIN_TEMPLATE_DESTINATION = path.join(
+    CYPRESS_PLUGINS,
+    'index.js'
+)
+const CUCUMBER_CONFIG_TEMPLATE_SOURCE = path.join(TEMPLATES, 'plugins.js')
+const CUCUMBER_CONFIG_TEMPLATE_DESTINATION = path.join(
+    CONSUMING_ROOT,
+    'cypress-cucumber-preprocessor.config.js'
+)
 
 module.exports = {
     CONSUMING_ROOT,
+    PACKAGE_JSON,
+    TEMPLATES,
+
     CYPRESS_ROOT,
     CYPRESS_FIXTURES,
     CYPRESS_INTEGRATION,
     CYPRESS_PLUGINS,
     CYPRESS_SUPPORT,
+    CYPRESS_CONFIG_PATH,
+    CYPRESS_CONFIG_ENV_PATH,
+    CYPRESS_SUPPORT_FILE_SOURCE,
+    CYPRESS_SUPPORT_FILE_DESTINATION,
+
+    CUCUMBER_PLUGIN_TEMPLATE_SOURCE,
+    CUCUMBER_PLUGIN_TEMPLATE_DESTINATION,
+    CUCUMBER_CONFIG_TEMPLATE_SOURCE,
+    CUCUMBER_CONFIG_TEMPLATE_DESTINATION,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,7 +982,7 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
   integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
 
-"@hapi/joi@^17.1.0":
+"@hapi/joi@^17.1.1":
   version "17.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
   integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
@@ -2248,10 +2248,10 @@ concat-stream@1.6.2, concat-stream@^1.6.0, concat-stream@^1.6.1, concat-stream@~
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concurrently@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.1.0.tgz#05523986ba7aaf4b58a49ddd658fab88fa783132"
-  integrity sha512-9ViZMu3OOCID3rBgU31mjBftro2chOop0G2u1olq1OuwRBVRw/GxHTg80TVJBUTJfoswMmEUeuOg1g1yu1X2dA==
+concurrently@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.2.0.tgz#ead55121d08a0fc817085584c123cedec2e08975"
+  integrity sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==
   dependencies:
     chalk "^2.4.2"
     date-fns "^2.0.1"
@@ -3770,7 +3770,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0:
+har-validator@~5.1.0, har-validator@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -5069,6 +5069,11 @@ minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -6178,6 +6183,32 @@ request@2.88.0, request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -6314,10 +6345,17 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
-rxjs@^6.3.3, rxjs@^6.5.2, rxjs@^6.5.3, rxjs@^6.5.4:
+rxjs@^6.3.3, rxjs@^6.5.2, rxjs@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.5:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -7184,7 +7222,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -7512,17 +7550,17 @@ vm-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-wait-on@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.1.tgz#c49ca18b1ea60580404feed9df76ab3af2425a56"
-  integrity sha512-x83fmTH2X0KL7vXoGt9aV5x4SMCvO8A/NbwWpaYYh4NJ16d3KSgbHwBy9dVdHj0B30cEhOFRvDob4fnpUmZxvA==
+wait-on@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.2.tgz#6ee9b5751b4e0329630abbb5fdba787802b32914"
+  integrity sha512-Qpmgm3Hw/sXm7xK68FBsYy5r+Uid94/QymwnEjn9GTpfiWTUVYm0bccivVwY/BXGYO2r+5Cd8S/DzrRZqHK/9w==
   dependencies:
-    "@hapi/joi" "^17.1.0"
+    "@hapi/joi" "^17.1.1"
     lodash "^4.17.15"
-    minimist "^1.2.0"
-    request "^2.88.0"
+    minimist "^1.2.5"
+    request "^2.88.2"
     request-promise-native "^1.0.8"
-    rxjs "^6.5.4"
+    rxjs "^6.5.5"
 
 walk-back@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
BREAKING CHANGE: The `d2-utils-cypress open` and `d2-utils-cypress run` now use `concurrently` and `wait-on` by default. If new behavior is undesired, it can be disabled with `--appStart ''`.

This PR does 3 things

1. refactors the `install` command's code
2. only writes the `testFiles` config to the `cypress.json` when using cucumber
3. Uses `concurrently` and `wait-on` when using the `open` and `run` commands