### PR TITLE
fix: correct url and needed props for login command

### DIFF
--- a/support.js
+++ b/support.js
@@ -60,17 +60,17 @@ const login = () => {
     const username = Cypress.env('dhis2_username')
     const password = Cypress.env('dhis2_password')
     const loginUrl = Cypress.env('dhis2_base_url')
-    const loginAuth = `Basic ${btoa(`${username}:${password}`)}`
 
     return cy.request({
         url: `${loginUrl}/${loginEndPoint}`,
         method: 'POST',
+        form: true,
+        followRedirect: true,
         body: {
             j_username: username,
             j_password: password,
             '2fa_code': '',
         },
-        headers: { Authorization: loginAuth },
     })
 }
 

--- a/support.js
+++ b/support.js
@@ -55,7 +55,7 @@ const get = (originalFn, selectors, options = {}) => {
  * because Cypress doesn't allow multiple domains per test:
  * https://docs.cypress.io/guides/guides/web-security.html#One-Superdomain-per-Test
  */
-const loginEndPoint = 'dhis-web-commons/security/login.action'
+const loginEndPoint = 'dhis-web-commons-security/login.action'
 const login = () => {
     const username = Cypress.env('dhis2_username')
     const password = Cypress.env('dhis2_password')


### PR DESCRIPTION
Fixes include:
* correct login url
* add `form` and `followRedirect` properties
* remove the auth header since it isn't needed for logging in