### PR TITLE
feat: expose the spec config option

### DIFF
--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -9,8 +9,8 @@ exports.builder = yargs =>
     yargs.option('appStart', appStart).option('waitOn', waitOn)
 
 exports.handler = argv => {
-    const { appStart, port, browser, waitOn } = argv
-    const cypressOptions = { mode: 'open', browser, port }
+    const { appStart, port, browser, waitOn, spec } = argv
+    const cypressOptions = { mode: 'open', browser, port, spec }
 
     log.info('d2-utils-cypress > open')
     execCypress({ appStart, waitOn, cypressOptions })

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,7 +17,13 @@ exports.builder = yargs =>
 
 exports.handler = argv => {
     const { appStart, headed, port, browser, waitOn, spec } = argv
-    const cypressOptions = { mode: 'run', headless: !headed, browser, port, spec }
+    const cypressOptions = {
+        mode: 'run',
+        headless: !headed,
+        browser,
+        port,
+        spec,
+    }
 
     log.info('d2-utils-cypress > run')
     execCypress({ appStart, waitOn, cypressOptions })

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -16,8 +16,8 @@ exports.builder = yargs =>
         .option('waitOn', waitOn)
 
 exports.handler = argv => {
-    const { appStart, headed, port, browser, waitOn } = argv
-    const cypressOptions = { mode: 'run', headless: !headed, browser, port }
+    const { appStart, headed, port, browser, waitOn, spec } = argv
+    const cypressOptions = { mode: 'run', headless: !headed, browser, port, spec }
 
     log.info('d2-utils-cypress > run')
     execCypress({ appStart, waitOn, cypressOptions })

--- a/src/tools/getCypressCommand.js
+++ b/src/tools/getCypressCommand.js
@@ -1,4 +1,4 @@
-exports.getCypressCommand = ({ mode, headless, port, browser, config }) => {
+exports.getCypressCommand = ({ mode, headless, port, browser, config, spec }) => {
     const cmd = 'npx'
 
     const modeArgs = mode === 'run' ? [...(headless ? [] : ['--headed'])] : []
@@ -10,6 +10,7 @@ exports.getCypressCommand = ({ mode, headless, port, browser, config }) => {
         ...(port ? ['--port', port] : []),
         ...(browser ? ['--browser', browser] : []),
         ...(config ? ['--config', config] : []),
+        ...(spec ? ['--spec', spec]: []),
         ...modeArgs,
     ]
 

--- a/src/tools/getCypressCommand.js
+++ b/src/tools/getCypressCommand.js
@@ -1,4 +1,11 @@
-exports.getCypressCommand = ({ mode, headless, port, browser, config, spec }) => {
+exports.getCypressCommand = ({
+    mode,
+    headless,
+    port,
+    browser,
+    config,
+    spec,
+}) => {
     const cmd = 'npx'
 
     const modeArgs = mode === 'run' ? [...(headless ? [] : ['--headed'])] : []
@@ -10,7 +17,7 @@ exports.getCypressCommand = ({ mode, headless, port, browser, config, spec }) =>
         ...(port ? ['--port', port] : []),
         ...(browser ? ['--browser', browser] : []),
         ...(config ? ['--config', config] : []),
-        ...(spec ? ['--spec', spec]: []),
+        ...(spec ? ['--spec', spec] : []),
         ...modeArgs,
     ]
 


### PR DESCRIPTION
The --spec option allows for specific test files to be run. This can be useful for running a set of smoke tests on ci, or running another subset of the tests.
