### PR TITLE
fix(cypress commands release): add publish config to package.json

### DIFF
--- a/packages/cypress-commands/package.json
+++ b/packages/cypress-commands/package.json
@@ -16,6 +16,9 @@
         "@dhis2/cli-style": "^7.0.0",
         "@dhis2/cli-app-scripts": "^4.0.4"
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "scripts": {
         "build": "d2-app-scripts build"
     }


### PR DESCRIPTION
Semantic release fails with

> `npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@dhis2%2fcypress-commands - You must sign up for private packages`

This is because I didn't add the `publishConfig` section to the package.json of the cypress-commands subpackage, see [here](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package).