### PR TITLE
fix(cypress commands release): run build script before deploying

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -41,5 +41,8 @@ jobs:
             - name: Lint
               run: yarn lint
 
+            - name: Build
+              run: yarn build
+
             - name: Publish to NPM
               run: npx @dhis2/cli-utils release --publish npm

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "format:text": "d2-style text apply",
         "format:staged": "yarn format:js --staged && yarn format:text --staged",
         "docs:build": "d2-utils-docsite build ./docs -o ./dist --jsdoc src/ --jsdocOutputFile api.md",
-        "docs:start": "d2-utils-docsite serve ./docs -o ./dist --jsdoc src/ --jsdocOutputFile api.md"
+        "docs:start": "d2-utils-docsite serve ./docs -o ./dist --jsdoc src/ --jsdocOutputFile api.md",
+        "build": "yarn workspace @dhis2/cypress-commands build"
     },
     "version": "3.0.1"
 }


### PR DESCRIPTION
The published package does not have the `build` directory.
I hope this will add the build directory and is not ignored because of the `.gitignore`.