### PR TITLE
fix: check the length as find always returns an object

### DIFF
--- a/packages/cypress-commands/src/commands/login.js
+++ b/packages/cypress-commands/src/commands/login.js
@@ -22,7 +22,7 @@ const loginDev = () => {
     cy.visit('/')
     cy.get('body')
         .then($body => {
-            if (!$body.find('input#server')) return cy.wrap(false)
+            if (!$body.find('input#server').length) return cy.wrap(false)
 
             const loginUrl = Cypress.env('dhis2_base_url')
             const username = Cypress.env('dhis2_username')


### PR DESCRIPTION
Current code causes login to fail if there is no `server` input field (will be the case when REACT_APP_DHIS2_BASE_URL is defined along side CYPRESS_DHIS2_BASE_URL)

https://docs.cypress.io/guides/core-concepts/conditional-testing.html#Element-existence