### PR TITLE
fix(run command): make command exit correctly

### DIFF
--- a/packages/cli/src/tools/waitOnAndCypress.js
+++ b/packages/cli/src/tools/waitOnAndCypress.js
@@ -1,5 +1,6 @@
-const { getCypressCommand } = require('./getCypressCommand.js')
+const log = require('@dhis2/cli-helpers-engine').reporter
 const concurrently = require('concurrently')
+const { getCypressCommand } = require('./getCypressCommand.js')
 
 exports.waitOnAndCypress = ({ appStart, waitOn, cypressOptions }) => {
     const { cmd, options } = getCypressCommand(cypressOptions)
@@ -7,11 +8,45 @@ exports.waitOnAndCypress = ({ appStart, waitOn, cypressOptions }) => {
     const waitOnCommand = `npx --no-install wait-on ${waitOn}`
     const waitAndCypress = `${waitOnCommand} && ${cypressCommand}`
 
+    // reflects the position of the cypress command passed to concurrently
+    const cypressCommandIndex = 1
+
     concurrently(
         [
             { command: appStart, name: 'app' },
             { command: waitAndCypress, name: 'cypress' },
         ],
-        { kill: ['success'] }
+        { killOthers: ['success', 'failure'] }
+    ).then(
+        () => {
+            cypressOptions.mode === 'run' && process.exit(0)
+        },
+        e => {
+            if (!e || !e.length) {
+                log.error('No commands have been executed')
+                process.exit(1)
+            }
+
+            const cypressResult = e.find(
+                ({ index }) => index === cypressCommandIndex
+            )
+
+            if (!cypressResult) {
+                log.error('The cypress command has not been executed')
+                process.exit(1)
+            }
+
+            if (typeof cypressResult.exitCode !== 'number') {
+                log.error('Unexpected result')
+            }
+
+            // sometimes e will contain objects with an exit code
+            if (cypressResult.exitCode === 0) {
+                process.exit(0)
+            }
+
+            log.error('The cypress command exited with a non-zero code')
+            process.exit(cypressResult.exitCode)
+        }
     )
 }


### PR DESCRIPTION
Fixes TECH-472

This will make sure that the `d2 utils cypress run` command exits properly.
The previous `concurrently` configuration didn't cause the process to exit when the `run` process has finished in some cases