### PR TITLE
fix: update the login button target

### DIFF
--- a/packages/cypress-commands/src/commands/login.js
+++ b/packages/cypress-commands/src/commands/login.js
@@ -31,7 +31,7 @@ const loginDev = () => {
             cy.get('#server').type(loginUrl)
             cy.get('#j_username').type(username)
             cy.get('#j_password').type(password)
-            cy.get('{button}', { prefix: 'dhis2-uicore' }).click()
+            cy.get('{loginsubmit}', { prefix: 'dhis2-adapter' }).click()
 
             return cy.wrap(true)
         })


### PR DESCRIPTION
Updates the target of the login button, as it has changed from `data-test="dhis2-uicore-button"` to `data-test="dhis2-adapter-loginsubmit"`, which causes the login fn to fail (screenshot)

![image](https://user-images.githubusercontent.com/12590483/99374358-c93e4580-28c2-11eb-9bd1-1f85af896615.png)
