### PR TITLE
fix(commands): add `-W` to `yarn add` when in yarn workspaces root

### DIFF
--- a/packages/cli/src/commands/install/ensureDependency.js
+++ b/packages/cli/src/commands/install/ensureDependency.js
@@ -3,12 +3,18 @@ const exec = require('@dhis2/cli-helpers-engine').exec
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const isYarnWorkspacesRoot = () => {
-    const rootDir = process.cwd()
-    const packageJson = fs.readFileSync(`${rootDir}/package.json`, {
-        encoding: 'utf8',
-    })
+    try {
+        const rootDir = process.cwd()
+        const packageJson = fs.readFileSync(`${rootDir}/package.json`, {
+            encoding: 'utf8',
+        })
 
-    return 'workspaces' in JSON.parse(packageJson)
+        return 'workspaces' in JSON.parse(packageJson)
+    } catch (_error) {
+        throw new Error(
+            `'cli-utils-cypress install' must be ran from the root of an npm package, but no valid 'package.json' was found in '${process.cwd()}'`
+        )
+    }
 }
 
 const installSupportPackage = (packageName, packageManager, cwd) => {

--- a/packages/cli/src/commands/install/ensureDependency.js
+++ b/packages/cli/src/commands/install/ensureDependency.js
@@ -12,7 +12,7 @@ const isYarnWorkspacesRoot = () => {
         return 'workspaces' in JSON.parse(packageJson)
     } catch (_error) {
         throw new Error(
-            `'cli-utils-cypress install' must be ran from the root of an npm package, but no valid 'package.json' was found in '${process.cwd()}'`
+            `'d2-utils-cypress install' must be run from the root of an npm package, but no valid 'package.json' was found in '${process.cwd()}'`
         )
     }
 }

--- a/packages/cli/src/commands/install/ensureDependency.js
+++ b/packages/cli/src/commands/install/ensureDependency.js
@@ -1,11 +1,25 @@
+const fs = require('fs')
 const exec = require('@dhis2/cli-helpers-engine').exec
 const log = require('@dhis2/cli-helpers-engine').reporter
 
+const isYarnWorkspacesRoot = () => {
+    const rootDir = process.cwd()
+    const packageJson = fs.readFileSync(`${rootDir}/package.json`, {
+        encoding: 'utf8',
+    })
+
+    return 'workspaces' in JSON.parse(packageJson)
+}
+
 const installSupportPackage = (packageName, packageManager, cwd) => {
-    const packageManagerArgs =
-        packageManager === 'yarn' ? ['add', '--dev'] : ['install', '-D']
+    const isYarn = packageManager === 'yarn'
+    const packageManagerArgs = isYarn ? ['add', '--dev'] : ['install', '-D']
 
     const args = [...packageManagerArgs, packageName]
+
+    if (isYarn && isYarnWorkspacesRoot()) {
+        args.push('-W')
+    }
 
     return exec({ cmd: packageManager, args, cwd })
 }


### PR DESCRIPTION
The command `d2-utils-cypress install` would not complete successfully in a yarn workspaces repo due to the missing `-W` flag. This fixes it, but I wonder if there would be a more elegant way to do this...