### PR TITLE
fix(commands): move jscodeshift to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "devDependencies": {
         "@dhis2/cli-style": "^7.2.1",
         "@dhis2/cli-utils-docsite": "^1.3.0",
-        "@dhis2/cli-app-scripts": "^4.0.4"
+        "@dhis2/cli-app-scripts": "^4.0.4",
+        "jest": "^26.6.3"
     }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,13 +25,10 @@
         "cypress-cucumber-preprocessor": "^2.0.1",
         "fs-extra": "^8.1.0",
         "inquirer": "^7.0.4",
+        "jscodeshift": "^0.11.0",
         "wait-on": "^4.0.2"
     },
     "publishConfig": {
         "access": "public"
-    },
-    "devDependencies": {
-        "jscodeshift": "^0.11.0",
-        "jest": "^26.6.3"
     }
 }

--- a/packages/cypress-commands/package.json
+++ b/packages/cypress-commands/package.json
@@ -12,16 +12,14 @@
     "author": "Jan-Gerke Salomon",
     "license": "BSD-3-Clause",
     "private": false,
+    "dependencies": {
+        "jscodeshift": "^0.11.0"
+    },
     "devDependencies": {
         "@babel/core": "^7.12.3",
         "@babel/preset-env": "^7.12.1",
         "@dhis2/cli-app-scripts": "^4.0.4",
-        "@dhis2/cli-style": "^7.2.1",
-        "assert-dir-equal": "^1.1.0",
-        "cross-spawn": "^7.0.3",
-        "fs-extra": "^9.0.1",
-        "jest": "^26.6.3",
-        "jscodeshift": "^0.11.0"
+        "@dhis2/cli-style": "^7.2.1"
     },
     "publishConfig": {
         "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3223,15 +3223,6 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assert-dir-equal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assert-dir-equal/-/assert-dir-equal-1.1.0.tgz#9ceb14dc81de82ecf836624868cd1b58ffc2f5fb"
-  integrity sha1-nOsU3IHeguz4NmJIaM0bWP/C9fs=
-  dependencies:
-    buffer-equal "0.0.0"
-    fs-readdir-recursive "0.0.1"
-    is-utf8 "~0.2.0"
-
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -4022,11 +4013,6 @@ buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
-buffer-equal@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.0.tgz#4a68196ac33522daa17ec99858b302a636b62cf1"
-  integrity sha1-SmgZasM1ItqhfsmYWLMCpja2LPE=
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -7400,11 +7386,6 @@ fs-mkdirp-stream@^1.0.0:
     graceful-fs "^4.1.11"
     through2 "^2.0.3"
 
-fs-readdir-recursive@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.0.1.tgz#f2223ab40293e436696d33b67f6b3e6d2e6a8c12"
-  integrity sha1-8iI6tAKT5DZpbTO2f2s+bS5qjBI=
-
 fs-then-native@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fs-then-native/-/fs-then-native-2.0.0.tgz#19a124d94d90c22c8e045f2e8dd6ebea36d48c67"
@@ -8846,7 +8827,7 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
-is-utf8@^0.2.1, is-utf8@~0.2.0:
+is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=


### PR DESCRIPTION
jscodeshift is not a dev dependency as it is used in the install command