### PR TITLE
fix(replace getfind mod): add checks to prevent crashes

### DIFF
--- a/packages/cypress-commands/codemods/replace-get-find-with-xxxxGetWithDataTest.js
+++ b/packages/cypress-commands/codemods/replace-get-find-with-xxxxGetWithDataTest.js
@@ -1,13 +1,35 @@
 const containsDataTestSyntax = new RegExp('{[^}]+}')
 
-const isGetOrFind = node =>
-    ['get', 'find'].includes(node.value.callee.property.name)
+const isGetOrFind = node => {
+    if (!node.value) return false
+    if (!node.value.callee) return false
+    if (!node.value.callee.property) return false
 
-const callExpressionHasArguments = node => node.value.arguments.length
+    return ['get', 'find'].includes(node.value.callee.property.name)
+}
+
+const callExpressionHasArguments = node => {
+    if (!node.value) return false
+    if (!node.value.arguments) return false
+
+    return node.value.arguments.length
+}
 
 const selectorArgumentContainsDataTestSyntax = node => {
+    if (!node.value) return false
+    if (!node.value.arguments) return false
+
     const selectorArguments = node.value.arguments
-    const [{ value }] = selectorArguments
+
+    if (!Array.isArray(selectorArguments) || !selectorArguments.length)
+        return false
+
+    const [firstItem] = selectorArguments
+
+    if (!firstItem) return false
+
+    const { value } = firstItem
+
     return containsDataTestSyntax.test(value)
 }
 
@@ -20,6 +42,10 @@ module.exports = function (fileInfo, api) {
         .filter(callExpressionHasArguments)
         .filter(selectorArgumentContainsDataTestSyntax)
         .forEach(node => {
+            if (!node.value) return false
+            if (!node.value.callee) return false
+            if (!node.value.callee.property) return false
+
             const { name } = node.value.callee.property
 
             node.value.callee.property.name =


### PR DESCRIPTION
This adds some checks to the callback functions to prevent errors from being thrown when trying to access a property of undefined.

OT: man.. optional chaining would be SO nice here..