### PR TITLE
fix(network-shim): only incrementally update missing request stub state

### DIFF
--- a/packages/cypress-commands/src/setups/enableNetworkShim/index.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/index.js
@@ -36,7 +36,7 @@ export function enableNetworkShim() {
             cy.get('@networkShimState').then(networkShimState => {
                 /*
                  * In capture mode the state needs to be incrementally updated
-                 * accross tests, so after every feature the entire plugin state
+                 * across tests, so after every feature the entire plugin state
                  * gets overwritten.
                  */
                 if (isCaptureMode()) {

--- a/packages/cypress-commands/src/setups/enableNetworkShim/index.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/index.js
@@ -1,4 +1,4 @@
-import { isDisabledMode, isCaptureMode } from './utils.js'
+import { isDisabledMode, isStubMode, isCaptureMode } from './utils.js'
 import captureRequests from './captureRequests.js'
 import stubRequests from './stubRequests.js'
 import validateVersionMinor from './validateVersionMinor.js'
@@ -24,6 +24,7 @@ export function enableNetworkShim() {
                 // This will mutate the state
                 captureRequests(networkShimState)
             } else {
+                // This also mutates the state
                 stubRequests(networkShimState)
             }
         })
@@ -33,8 +34,26 @@ export function enableNetworkShim() {
         if (!isDisabledMode()) {
             // First get the updated local state from the alias
             cy.get('@networkShimState').then(networkShimState => {
-                // Then update the plugin state
-                cy.task('setNetworkShimState', networkShimState)
+                /*
+                 * In capture mode the state needs to be incrementally updated
+                 * accross tests, so after every feature the entire plugin state
+                 * gets overwritten.
+                 */
+                if (isCaptureMode()) {
+                    cy.task('setNetworkShimState', networkShimState)
+                }
+                /*
+                 * In stub mode the state needs to be kept static across features
+                 * apart from the missing request stubs which do need to be
+                 * incrementally updated across features. So in stub mode we only
+                 * update that state property in the plugin.
+                 */
+                if (isStubMode()) {
+                    cy.task(
+                        'setNetworkShimMissingRequestStubs',
+                        networkShimState.missingRequestStubs
+                    )
+                }
             })
         }
     })

--- a/packages/cypress-plugins/src/plugins/networkShim/index.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/index.js
@@ -37,6 +37,12 @@ module.exports = function networkShim(
             state = newState
             return state
         },
+        setNetworkShimMissingRequestStubs(missingRequestStubs) {
+            if (Array.isArray(missingRequestStubs)) {
+                state.missingRequestStubs = missingRequestStubs
+            }
+            return state
+        },
     })
 
     on('after:run', results => {


### PR DESCRIPTION
CLI-48 turns out to be a regression from yesterday #201. It has to do with the fact that state changes during a test in a stub run (it’s always done that) and state now also being persisted across tests in a stub run (it used to do this in capture mode only).

I considered two options for addressing this issue:
1. The current solution which keeps using the state to keep track of missing request stubs across features
2. A more involved, but arguably cleaner, solution which would involve keeping track of missing request stubs during stub mode via a dedicated state object. 

I opted for 1 because this doesn't require as many changes, and hope the comments compensate somewhat for the complicated logic.