### PR TITLE
fix(network-shim): use electron instead of chrome for runs

### DIFF
--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -18,9 +18,6 @@ exports.builder = yargs =>
         .option('browser', {
             describe: 'Browser name or filesystem path',
             type: 'string',
-            // TODO: Should default to electron but the network shim
-            // will require support for 304s for that
-            default: 'chrome',
         })
         .option('capture', {
             describe: 'Enable netowrk shim capture mode',


### PR DESCRIPTION
The fact that we were using Chrome for cypress runs was a relic of the past that should have been removed. At some point in time, the Network Shim did not have support for 304 requests and to work around this issue I was using Chrome and passing a flag to it to disable the network caching. I had to use Chrome because it wasn't possible to disable the Electron network cache with a flag.

However, I have added support for 304 requests quite a while ago, so we should use Electron instead since that comes with cypress and is therefore guaranteed to be available. I have simply removed the default field, because I think it is best if we use whichever browser cypress uses as default for runs, so I didn't want to set it explicitly in our CLI command.

For reference, here is the part of the code that provides support for 304s:
https://github.com/dhis2/cli-utils-cypress/blob/b14a8f281707023245c9998eaf5f3452e9977211/packages/cypress-commands/src/setups/enableNetworkShim/captureRequests.js#L92-L146