### PR TITLE
fix: use upper-snake-case environment variable names

### DIFF
--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -3,9 +3,9 @@
 This command will log a specified user in through the login endpoint.
 It uses the following required environment variables:
 
--   `dhis2_username`
--   `dhis2_password`
--   `dhis2_base_url`
+-   `DHIS2_USERNAME`
+-   `DHIS2_PASSWORD`
+-   `DHIS2_BASE_URL`
 
 Please refer to the [official
 docs](https://docs.cypress.io/guides/guides/environment-variables.html) for

--- a/docs/guides/add-login-credentials.md
+++ b/docs/guides/add-login-credentials.md
@@ -2,9 +2,9 @@
 
 The cypress utility expects three values to be present in that file:
 
-1. `dhis2_base_url`
-1. `dhis2_username`
-1. `dhis2_password`
+1. `DHIS2_BASE_URL`
+1. `DHIS2_USERNAME`
+1. `DHIS2_PASSWORD`
 
 There are various ways how to add enviroment variables to your cypress setup,
 please refer to the official docs to get an overview.
@@ -20,9 +20,9 @@ Here is an example what a `cypress.env.json` could look like
 
 ```json
 {
-    "dhis2_base_url": "https://localhost:8080",
-    "dhis2_username": "admin",
-    "dhis2_password": "district"
+    "DHIS2_BASE_URL": "https://localhost:8080",
+    "DHIS2_USERNAME": "admin",
+    "DHIS2_PASSWORD": "district"
 }
 ```
 

--- a/docs/helpers/dataTestNameToSelector.md
+++ b/docs/helpers/dataTestNameToSelector.md
@@ -12,7 +12,7 @@ const customSelector = '{navigation-item}'
 const validCssSelector = dataTestNameToSelector(customSelector)
 ```
 
-With the `dhis2_datatest_prefix` env variable set to `dhis2-libname`:
+With the `DHIS2_DATATEST_PREFIX` env variable set to `dhis2-libname`:
 
 ```js
 const customSelector = '{navigation-item}'
@@ -38,7 +38,7 @@ An individual data test selector with custom syntax.
 
 **prefix**<br />
 Type: String<br />
-An optional prefix. By default the function uses the `dhis2_datatest_prefix`
+An optional prefix. By default the function uses the `DHIS2_DATATEST_PREFIX`
 environment variable or use an empty string when the env var has not been set.
 
 ---

--- a/docs/helpers/parseSelectorWithDataTest.md
+++ b/docs/helpers/parseSelectorWithDataTest.md
@@ -10,7 +10,7 @@ const customSelector = '{navigation-item}:first-child {link-text}'
 const validCssSelector = dataTestNameToSelector(customSelector)
 ```
 
-With the `dhis2_datatest_prefix` env variable set to `dhis2-libname`:
+With the `DHIS2_DATATEST_PREFIX` env variable set to `dhis2-libname`:
 
 ```js
 const customSelector = '{navigation-item}:first-child {link-text}'
@@ -38,7 +38,7 @@ A data test selector with custom syntax.
 
 **prefix**<br />
 Type: String<br />
-An optional prefix. By default the function uses the `dhis2_datatest_prefix`
+An optional prefix. By default the function uses the `DHIS2_DATATEST_PREFIX`
 environment variable or use an empty string when the env var has not been set.
 
 ---

--- a/examples/platform-app/cypress.env.json
+++ b/examples/platform-app/cypress.env.json
@@ -1,6 +1,6 @@
 {
-    "dhis2_username": "admin",
-    "dhis2_password": "district",
-    "dhis2_base_url": "http://localhost:8080",
-    "dhis2_datatest_prefix": "networkshim-platformapp"
+    "DHIS2_USERNAME": "admin",
+    "DHIS2_PASSWORD": "district",
+    "DHIS2_BASE_URL": "http://localhost:8080",
+    "DHIS2_DATATEST_PREFIX": "networkshim-platformapp"
 }

--- a/examples/testing-network-shim-app/cypress.env.json
+++ b/examples/testing-network-shim-app/cypress.env.json
@@ -1,6 +1,6 @@
 {
-    "dhis2_base_url": "http://localhost:1337",
-    "dhis2_username": "admin",
-    "dhis2_password": "district",
-    "dhis2_datatest_prefix": "testing-network-shim-app"
+    "DHIS2_BASE_URL": "http://localhost:1337",
+    "DHIS2_USERNAME": "admin",
+    "DHIS2_PASSWORD": "district",
+    "DHIS2_DATATEST_PREFIX": "testing-network-shim-app"
 }

--- a/examples/testing-network-shim-app/cypress/support/index.js
+++ b/examples/testing-network-shim-app/cypress/support/index.js
@@ -2,7 +2,7 @@ import { enableNetworkShim } from '@dhis2/cypress-commands'
 import { resetDb } from '../../src/json-server/resetDb'
 
 afterEach(() => {
-    if (Cypress.env('dhis2_api_stub_mode') === 'CAPTURE') {
+    if (Cypress.env('DHIS2_API_STUB_MODE') === 'CAPTURE') {
         resetDb()
     }
 })

--- a/packages/cli/helper/dataTestNameToSelector.js
+++ b/packages/cli/helper/dataTestNameToSelector.js
@@ -4,7 +4,7 @@
  * @returns {string}
  */
 const dataTestNameToSelector = (dataTestName, prefix) => {
-    const defaultPrefix = Cypress.env('dhis2_datatest_prefix') || ''
+    const defaultPrefix = Cypress.env('DHIS2_DATATEST_PREFIX') || ''
     // Empty string is a valid value, so check for undefined
     const actualPrefix = typeof prefix === 'undefined' ? defaultPrefix : prefix
     const dataTestId = actualPrefix

--- a/packages/cli/src/commands/install/setDataTestPrefix.js
+++ b/packages/cli/src/commands/install/setDataTestPrefix.js
@@ -48,7 +48,7 @@ module.exports.setDataTestPrefix = async ({ options, state, paths }) => {
         ...state,
         cypressEnvJson: {
             ...state.cypressEnvJson,
-            dhis2_datatest_prefix: envAnswers.dhis2DatatestPrefix,
+            DHIS2_DATATEST_PREFIX: envAnswers.dhis2DatatestPrefix,
         },
     }
 }

--- a/packages/cli/src/commands/install/setLoginBackendUrl.js
+++ b/packages/cli/src/commands/install/setLoginBackendUrl.js
@@ -18,7 +18,7 @@ module.exports.setLoginBackendUrl = async ({ options, state }) => {
         ...state,
         cypressEnvJson: {
             ...state.cypressEnvJson,
-            dhis2_base_url: envAnswers.dhis2Url,
+            DHIS2_BASE_URL: envAnswers.dhis2Url,
         },
     }
 }

--- a/packages/cli/src/commands/install/setLoginPassword.js
+++ b/packages/cli/src/commands/install/setLoginPassword.js
@@ -18,7 +18,7 @@ module.exports.setLoginPassword = async ({ options, state }) => {
         ...state,
         cypressEnvJson: {
             ...state.cypressEnvJson,
-            dhis2_password: envAnswers.password,
+            DHIS2_PASSWORD: envAnswers.password,
         },
     }
 }

--- a/packages/cli/src/commands/install/setLoginUser.js
+++ b/packages/cli/src/commands/install/setLoginUser.js
@@ -18,7 +18,7 @@ module.exports.setLoginUser = async ({ options, state }) => {
         ...state,
         cypressEnvJson: {
             ...state.cypressEnvJson,
-            dhis2_username: envAnswers.username,
+            DHIS2_USERNAME: envAnswers.username,
         },
     }
 }

--- a/packages/cli/src/tools/getCypressCommandEnvArgs.js
+++ b/packages/cli/src/tools/getCypressCommandEnvArgs.js
@@ -13,15 +13,15 @@ exports.getCypressCommandEnvArgs = ({
 
     if (capture || stub) {
         const mode = capture ? 'CAPTURE' : 'STUB'
-        envArgs.push(`dhis2_api_stub_mode=${mode}`)
+        envArgs.push(`DHIS2_API_STUB_MODE=${mode}`)
     }
 
     if (dhis2CoreUrl) {
-        envArgs.push(`dhis2_base_url=${dhis2CoreUrl}`)
+        envArgs.push(`DHIS2_BASE_URL=${dhis2CoreUrl}`)
     }
 
     if (serverMinorVersion) {
-        envArgs.push(`dhis2_server_minor_version=${serverMinorVersion}`)
+        envArgs.push(`DHIS2_SERVER_MINOR_VERSION=${serverMinorVersion}`)
     }
 
     return envArgs.length === 0 ? [] : ['--env', envArgs.join(',')]

--- a/packages/cypress-commands/src/commands/login.js
+++ b/packages/cypress-commands/src/commands/login.js
@@ -6,9 +6,9 @@ export const LOGIN_ENDPOINT = 'dhis-web-commons-security/login.action'
  * https://docs.cypress.io/guides/guides/web-security.html#One-Superdomain-per-Test
  */
 export const login = () => {
-    const username = Cypress.env('dhis2_username')
-    const password = Cypress.env('dhis2_password')
-    const loginUrl = Cypress.env('dhis2_base_url')
+    const username = Cypress.env('DHIS2_USERNAME')
+    const password = Cypress.env('DHIS2_PASSWORD')
+    const loginUrl = Cypress.env('DHIS2_BASE_URL')
 
     cy.request({
         url: `${loginUrl}/${LOGIN_ENDPOINT}`,

--- a/packages/cypress-commands/src/helper/dataTestNameToSelector.js
+++ b/packages/cypress-commands/src/helper/dataTestNameToSelector.js
@@ -4,7 +4,7 @@
  * @returns {string}
  */
 export const dataTestNameToSelector = (dataTestName, prefix) => {
-    const defaultPrefix = Cypress.env('dhis2_datatest_prefix') || ''
+    const defaultPrefix = Cypress.env('DHIS2_DATATEST_PREFIX') || ''
     // Empty string is a valid value, so check for undefined
     const actualPrefix = typeof prefix === 'undefined' ? defaultPrefix : prefix
     const dataTestId = actualPrefix

--- a/packages/cypress-commands/src/setups/enableAutoLogin.js
+++ b/packages/cypress-commands/src/setups/enableAutoLogin.js
@@ -1,5 +1,5 @@
 export const enableAutoLogin = () => {
-    if (Cypress.env('dhis2_api_stub_mode') === 'STUB') {
+    if (Cypress.env('DHIS2_API_STUB_MODE') === 'STUB') {
         return
     }
 
@@ -14,7 +14,7 @@ export const enableAutoLogin = () => {
         // This ensures the app platform knows which URL to use even if
         // REACT_APP_DHIS2_BASE_URL is undefined It also ensures that the value
         // from the cypress env is used instead of REACT_APP_DHIS2_BASE_URL
-        const loginUrl = Cypress.env('dhis2_base_url')
+        const loginUrl = Cypress.env('DHIS2_BASE_URL')
         localStorage.setItem('DHIS2_BASE_URL', loginUrl)
     })
 }

--- a/packages/cypress-commands/src/setups/enableNetworkShim/utils.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/utils.js
@@ -1,18 +1,18 @@
 export const isDisabledMode = () =>
-    !Cypress.env('dhis2_api_stub_mode') ||
-    Cypress.env('dhis2_api_stub_mode') === 'DISABLED'
+    !Cypress.env('DHIS2_API_STUB_MODE') ||
+    Cypress.env('DHIS2_API_STUB_MODE') === 'DISABLED'
 
 export const isCaptureMode = () =>
-    Cypress.env('dhis2_api_stub_mode') === 'CAPTURE'
+    Cypress.env('DHIS2_API_STUB_MODE') === 'CAPTURE'
 
-export const isStubMode = () => Cypress.env('dhis2_api_stub_mode') === 'STUB'
+export const isStubMode = () => Cypress.env('DHIS2_API_STUB_MODE') === 'STUB'
 
 export const getApiBaseUrl = () => {
-    const baseUrl = Cypress.env('dhis2_base_url')
+    const baseUrl = Cypress.env('DHIS2_BASE_URL')
 
     if (!baseUrl) {
         throw new Error(
-            'No `dhis2_base_url` found. Please make sure to add it to `cypress.env.json`'
+            'No `DHIS2_BASE_URL` found. Please make sure to add it to `cypress.env.json`'
         )
     }
 

--- a/packages/cypress-commands/src/setups/enableNetworkShim/validateVersionMinor.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/validateVersionMinor.js
@@ -4,14 +4,14 @@
  * @returns {void}
  */
 export default function validateVersionMinor() {
-    const baseUrl = Cypress.env('dhis2_base_url')
+    const baseUrl = Cypress.env('DHIS2_BASE_URL')
 
     cy.request(`${baseUrl}/api/system/info`).then(response => {
         if (response.status !== 200) {
             throw new Error('Could not request system minor version')
         }
 
-        const providedVersionMinor = Cypress.env('dhis2_server_minor_version')
+        const providedVersionMinor = Cypress.env('DHIS2_SERVER_MINOR_VERSION')
         const versionStr = response.body.version
         const foundVersionMinor = parseInt(versionStr.split(/\.|-/)[1])
 

--- a/packages/cypress-plugins/src/plugins/networkShim/clearNetworkFixtures.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/clearNetworkFixtures.js
@@ -5,7 +5,7 @@ const log = require('@dhis2/cli-helpers-engine').reporter
 
 module.exports = function clearNetworkFixtures({ fixturesFolder, env }) {
     try {
-        const serverMinorVersion = env.dhis2_server_minor_version.toString()
+        const serverMinorVersion = env.DHIS2_SERVER_MINOR_VERSION.toString()
         const versionMinorDir = path.join(fixturesFolder, serverMinorVersion)
 
         if (fs.existsSync(versionMinorDir)) {

--- a/packages/cypress-plugins/src/plugins/networkShim/createState.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/createState.js
@@ -58,12 +58,12 @@ const { isCaptureMode, isStubMode, getFixturesDir } = require('./utils.js')
 module.exports = function createState(cypressConfig, hosts, staticResources) {
     try {
         const env = cypressConfig.env
-        const serverMinorVersion = env.dhis2_server_minor_version
+        const serverMinorVersion = env.DHIS2_SERVER_MINOR_VERSION
         const fixturesDir = getFixturesDir(cypressConfig)
         const config = {
             serverMinorVersion,
-            mode: env.dhis2_api_stub_mode,
-            hosts: hosts || [env.dhis2_base_url],
+            mode: env.DHIS2_API_STUB_MODE,
+            hosts: hosts || [env.DHIS2_BASE_URL],
             staticResources,
         }
 

--- a/packages/cypress-plugins/src/plugins/networkShim/utils.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/utils.js
@@ -1,22 +1,22 @@
 const path = require('path')
 
 module.exports.isCaptureMode = function (env) {
-    return env.dhis2_api_stub_mode === 'CAPTURE'
+    return env.DHIS2_API_STUB_MODE === 'CAPTURE'
 }
 
 module.exports.isStubMode = function (env) {
-    return env.dhis2_api_stub_mode === 'STUB'
+    return env.DHIS2_API_STUB_MODE === 'STUB'
 }
 
 module.exports.isDisabledMode = function (env) {
-    return !env.dhis2_api_stub_mode || env.dhis2_api_stub_mode === 'DISABLED'
+    return !env.DHIS2_API_STUB_MODE || env.DHIS2_API_STUB_MODE === 'DISABLED'
 }
 
 module.exports.getFixturesDir = function ({ fixturesFolder, env }) {
     return path.join(
         fixturesFolder,
         'network',
-        env.dhis2_server_minor_version.toString()
+        env.DHIS2_SERVER_MINOR_VERSION.toString()
     )
 }
 


### PR DESCRIPTION
BREAKING CHANGE: all environment variables are now in `UPPER_SNAKE_CASE`, aligned with the bash convention. This means apps  will have to change their `cypress.env.json` and perhaps some scripts in `package.json`