### PR TITLE
docs(network-shim): add guide explaining usage and configuration

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
     -   [**Enabling auto login**](guides/enable-auto-login)
     -   [**Custom data test syntax**](guides/custom-data-test-syntax)
     -   [**Adding login credentials**](guides/add-login-credentials)
+    -   [**Using the network shim**](guides/using-the-network-shim)
 -   [**API: Commands**](commands)
     -   [**getWithDataTest**](commands/getWithDataTest)
     -   [**findWithDataTest**](commands/findWithDataTest)

--- a/docs/guides/using-the-network-shim.md
+++ b/docs/guides/using-the-network-shim.md
@@ -1,0 +1,286 @@
+# Using the Network Shim
+
+#### Table of contents
+
+-   **[About](#about)**
+-   **[Quick setup](#quick-setup)**
+-   **[General workflow](#general-workflow)**
+-   **[Configuration](#configuration)**
+    -   **[Cypress](#cypress)**
+        -   **[Environment variables](#environment-variables)**
+        -   **[Plugins file](#plugins-file)**
+        -   **[Support file](#support-file)**
+    -   **[Package scripts and dependencies](#package-scripts-and-dependencies)**
+    -   **[GitHub workflow](#github-workflow)**
+
+## About
+
+The Network Shim makes it possible to record and play back network traffic during a cypress tests run. This means no live network requests need to be made when running e2e tests on CI, which is generally considered an anti-pattern as it can lead to flaky tests.
+
+It consists of a cypress plugin as well as a setup utility to be placed in cypress' support file. These have to be used in conjunction. Under the hood it uses the cypress `cy.intercept()` API to intercept network traffic during a test run. It has three different _modes_:
+
+-   `capture`: when operating in this mode, the Network Shim will allow all outgoing network traffic to the specified hosts and and store each response as a fixture (JSON file).
+-   `stub`: in this mode the Network Shim intercepts all outgoing requests to the specified hosts. It will reply with the responses from previously recorded fixtures.
+-   `live`: the Network Shim does not interfere with any network traffic when this mode is enabled. All network traffic is live.
+
+By recording fixtures during a _capture run_ and then using these fixtures during a _stub run_ a full cypress test suite can be executed without a live backend. This is especially useful when running cypress tests on CI. Since it is no longer necessary to have a network connection and a backend, the cypress tests on CI can be more stable. One caveat is that the tests are slightly less realistic, since the network traffic is mocked, so the developer will have to make sure that the recorded fixtures are kept up-to-date.
+
+A capture or stub run is executed for a specific DHIS2 api version and individual fixtures for each version are recorded/played-back during a run. This makes it easier to do cross-version testing for _feature-toggling_ apps.
+
+## Quick setup
+
+The command-line-tool in the package `@dhis2/cli-utils-cypress` comes with an `install` command which generates most of the configuration files documented below. See the [Setup Cypress for your project](https://cli-utils-cypress.dhis2.nu/#/guides/setting-up-cli-tool) guide for more info on how to do this.
+
+To get up-and-running quickly do the following:
+
+1.  Install the cli tool
+
+    ```bash
+    yarn add --dev @dhis2/cli-utils-cypress
+    ```
+
+    <br/>
+
+1.  Issue the install command to generate a working setup
+
+    ```bash
+    d2-utils-cypress install all
+    ```
+
+    (_Instead of `all` another "group" can be specified._)
+    <br/>
+
+1.  Ensure to git-ignore the `./cypress.env.json` file
+    <br/>
+
+1.  Install the peer dependency
+
+    ```bash
+    yarn add cypress
+    ```
+
+    (_Also install `cypress-cucumber` when applicable_)
+    <br/>
+
+1.  Install tools needed to run the scripts in `package.json`:
+    _(or install the `start-server-and-test` package instead)_
+
+    ```bash
+    yarn install -D wait-on concurrently
+    ```
+
+        <br/>
+
+1.  Create scripts `package.json` as demonstrated [here](#package-scripts-and-dependencies)
+    <br/>
+
+1.  Perform a capture run to generate fixtures and commit the generated files:
+
+    ```bash
+    yarn cy:capture
+    ```
+
+    <br/>
+
+1.  Copy-paste GitHub Actions job from [here](https://github.com/dhis2/workflows/blob/master/ci/dhis2-verify-app.yml#L73-L105) into the app's workflow to enable running e2e tests on CI
+    <br/>
+
+## General workflow
+
+Once the Network Shim is up-and-running, the general steps required get a cypress test-suite running on CI are as follows:
+
+1. Ensure a live backend is up and running
+1. Ensure a fully passing cypress test-suite is in place
+1. Ensure the CI workflow includes a job that runs the cypress test suite in stub mode
+1. Execute a capture run, which will produce fixture files
+1. Commit the generated fixture files and push to the remote
+1. The test suite will now execute on CI
+
+To setup cross-version testing essentially means taking some of the steps above multiple times:
+
+-   Perform multiple capture runs against different versions of the live backend, so network fixtures are created for all these versions
+-   Define multiple jobs in the GitHub workflow that execute a stub run against these different versions
+
+## Configuration
+
+A workflow as described above consists of a few moving parts, which are described in more details below. **However, running the `d2-utils-cypress install` command should create all required files**.
+
+### Cypress
+
+#### Environment variables
+
+The Network Shim depends on a few cypress environment variables. These can be set using the `--env` flag when interacting with the cypress CLI, but base values should be provided as well in via the following configuration files, see the [cypress docs](https://docs.cypress.io/guides/guides/environment-variables) for more information.
+
+##### `./cypress.json`
+
+This file is meant to be checked into source control, so should not contain any sensitive or machine-specific information.
+
+```json
+{
+    "baseUrl": "APP_URL",
+    "projectId": "PROJECT_ID",
+    "testFiles": "TEST_FILES",
+    "experimentalInteractiveRunEvents": true,
+    "video": false,
+    "env": {
+        "dhis2DataTestPrefix": "DATA_TEST_PREFIX",
+        "networkMode": "live", // default mode for the Network Shim
+        "dhis2ApiVersion": "value_from_prompt"
+    }
+}
+```
+
+_Notes:_
+
+-   _Only the `env` fields are required directly by the Network Shim, but other fields are included in this example since they are required to have a working cypress setup._
+-   _Interactive runs are not formally supported by the Network Shim, because `cypress open` (interactive mode) and `cypress run` have different behaviour regarding the plugin events. However, cypress is attempting to smooth things over and by setting `experimentalInteractiveRunEvents` to `true` it should theoretically be possible to at at least use stub mode in interactive mode._
+
+##### `./cypress.env.json`
+
+This file is meant to be git-ignored and we can use this to set local environment variable that may contain sensitive or machine-dependent information.
+
+```json
+{
+    "dhis2Username": "USERNAME", // secret
+    "dhis2Password": "PASSWORD", // secret
+    "dhis2BaseUrl": "DHIS2_BASE_URL" // machine specific
+}
+```
+
+_Note that `dhis2Username` and `dhis2Password` are not required directly by the Network Shim, but by the `enableAutologin` setup. They are included in this example since they will be needed for most use-cases._
+
+#### Plugins file
+
+The `networkShim` plugin should be imported and initialised in the cypress plugins file, see the [cypress docs](https://docs.cypress.io/guides/tooling/plugins-guide#Using-a-plugin) for more info. The plugin function doesn't require the second `config` argument most plugins accept.
+
+```js
+const { networkShim } = require('@dhis2/cypress-plugins')
+
+module.exports = (on, config) => {
+    networkShim(on)
+}
+```
+
+The `networkShim` plugin accepts a second `options` argument. For most DHIS2 platform apps the default options will be correct so there will be no need to pass a second argument.
+
+For most DHIS2 Cypress test suites the `enableAutoLogin` plugin can help reduce repetitive login steps in tests. In turn, the `enableAutoLogin` setup utility requires the `chromeAllowXSiteCookies` plugin when using Chrome. So a typical DHIS2 app will use this plugin alongside the `networkShim`.
+
+Below is an example of a plugins file with `options` supplied to the `networkShim` and used in conjunction with `chromeAllowXSiteCookies`:
+
+```js
+const {
+    networkShim,
+    chromeAllowXSiteCookies,
+} = require('@dhis2/cypress-plugins')
+
+const options = {
+    hosts: ['https://main-api.com', 'https://secondary-api.com'],
+    staticResources: [
+        '/endpoint-which-always-returns-the-same-data',
+        '/another-endpoint-which-always-returns-the-same-data',
+    ],
+}
+
+module.exports = (on, config) => {
+    networkShim(on, options)
+    chromeAllowXSiteCookies(on, config)
+}
+```
+
+#### Support file
+
+The `enableNetworkShim` setup should be imported and executed in the [cypress support file](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file). This function accepts no arguments. Typically, in a DHIS2 platform app, the `enableAutoLogin` setup is required so individual tests don't require login steps, which means the file should look like this:
+
+```js
+import { enableAutoLogin, enableNetworkShim } from '@dhis2/cypress-commands'
+
+enableAutoLogin()
+enableNetworkShim()
+```
+
+### Package scripts and dependencies
+
+##### `./package.json`
+
+The following `devDependencies` are required:
+
+```json
+"devDependencies": {
+    "@dhis2/cypress-commands": "^#.#.#",
+    "@dhis2/cypress-plugins": "^#.#.#",
+},
+```
+
+And it is recommended to add some convenience commands to the `scripts` section, for example:
+
+```json
+"scripts": {
+    "cy:start": "BROWSER=none yarn start",
+    "cy:open": "wait-on 'http-get://localhost:3000' && cypress open",
+    "cy:run": "wait-on 'http-get://localhost:3000' && cypress run",
+    "cy:capture": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=capture' --kill-others --success first",
+    "cy:stub": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=stub' --kill-others --success first",
+},
+```
+
+_Note that `cy:stub` here is meant to perform a local stub-run, the stub run on CI should be configured differently as explained in the [GitHub workflow](#github-workflow) section._
+
+Some notes:
+
+1. These example scripts assume both `wait-on` and `concurrently` are installed available. If this is not the case, run:
+    ```bash
+    yarn add -D wait-on concurrently
+    ```
+1. As an alternative to using `wait-on` and `concurrently` the package `start-server-and-test` could be used, which is recommended by cypress. An example can be found [here](https://github.com/dhis2/scheduler-app/blob/8af8ae7b8b319384f14b510b7017f2beea730f5c/package.json#L14-L16).
+1. Setting `BROWSER=none` before running `yarn start` simply means that no browser tab is going to be opened/activated once the app is ready.
+1. In the example above no `dhis2ApiVersion` is passed as a cypress env variable, even though the Network Shim relies on this. This works because that variable is declared in `./cypress.env.json` so that value is used. See the [cypress docs](https://docs.cypress.io/guides/guides/environment-variables) for more info.
+1. The example above only takes into account testing against a single backend version. If an additional v36 version of DHIS2 core was available on `http://localhost:8081` and the test-suite should be executed against that backend as well, the following scripts could be added:
+    ```json
+    "cy:capture-v36": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=capture,dhis2BaseUrl=http://localhost:8081,dhis2ApiVersion=36' --kill-others --success first",
+    "cy:stub-v36": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=stub,dhis2BaseUrl=http://localhost:8081,dhis2ApiVersion=36' --kill-others --success first",
+    ```
+
+### GitHub workflow
+
+At DHIS2 we use GitHub Actions for CI/CD, and we provide a workflow template for DHIS2 platform apps [here](https://github.com/dhis2/workflows/blob/master/ci/dhis2-verify-app.yml#L73-L105). A typical DHIS2 platform-app will probably use the full `dhis2-verify-app` workflow and store this in `./.github/workflows/dhis2-verify-app.yml`. Once the Network Shim has been configured and a capture run has been executed, all that is needed is to uncomment the e2e job.
+
+Below is an illustration of such a job to provide some additional info:
+
+-   The job uses the `cypress-io/github-action@v2` GitHub action.
+-   The required environment variables are set via the `env` parameter, note that:
+    -   They need to be prefixed with `CYPRESS_`.
+    -   The `dhis2Username` and `dhis2Password` variables are not needed because we only do a stub run on CI.
+-   To perform cross-version testing, more steps like this could be added, specifying a different value for `CYPRESS_dhis2BaseUrl` and `CYPRESS_dhis2ApiVersion`.
+-   In the example below `record` and `parallel` have been enabled. This will only work if the project has been registered at the cypress dashboard and has a valid record key.
+
+```yml
+e2e:
+    runs-on: ubuntu-latest
+    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
+    strategy:
+        fail-fast: false
+        matrix:
+            containers: [1, 2, 3, 4]
+    steps:
+        - name: Checkout
+            uses: actions/checkout@v2
+        - uses: actions/setup-node@v1
+            with:
+                node-version: 12.x
+        - name: End-to-End tests
+            uses: cypress-io/github-action@v2
+            with:
+                start: yarn cy:start
+                wait-on: 'http://localhost:3000'
+                wait-on-timeout: 300
+                record: true
+                parallel: true
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                CYPRESS_dhis2BaseUrl: http://localhost:8080
+                CYPRESS_dhis2ApiVersion: 37
+                CYPRESS_networkMode: stub
+```
+
+Github actions were used as an example in these docs, but it is also possible to setup cypress test-runs with these plugins on other CI solutions.

--- a/examples/platform-app/package.json
+++ b/examples/platform-app/package.json
@@ -13,8 +13,8 @@
         "format": "d2-style apply",
         "format:staged": "yarn format --staged",
         "cy:start": "BROWSER=none yarn start",
-        "cy:open": "wait-on 'http://localhost:3000' && cypress open",
-        "cy:run": "wait-on 'http://localhost:3000' && cypress run",
+        "cy:open": "wait-on 'http-get://localhost:3000' && cypress open",
+        "cy:run": "wait-on 'http-get://localhost:3000' && cypress run",
         "cy:capture": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=capture' --kill-others --success first",
         "cy:stub": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=stub' --kill-others --success first",
         "cy:capture-and-stub": "yarn cy:capture && yarn cy:stub"

--- a/examples/testing-network-shim-app/package.json
+++ b/examples/testing-network-shim-app/package.json
@@ -21,8 +21,8 @@
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "cy:start": "BROWSER=none yarn start",
-        "cy:open": "wait-on 'http://localhost:3000' && cypress open",
-        "cy:run": "wait-on 'http://localhost:3000' && cypress run",
+        "cy:open": "wait-on 'http-get://localhost:3000' && cypress open",
+        "cy:run": "wait-on 'http-get://localhost:3000' && cypress run",
         "cy:capture": "concurrently 'yarn serve' 'yarn cy:start' 'yarn cy:run --env networkMode=capture' --kill-others --success first",
         "cy:stub": "concurrently 'yarn cy:start' 'yarn cy:run --env networkMode=stub' --kill-others --success first",
         "cy:capture-and-stub": "yarn cy:capture && yarn cy:stub"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,7 +4075,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
+ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -5528,18 +5528,6 @@ chai@^4.1.2:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chai@^4.2.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
-  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.1"
-    type-detect "^4.0.5"
-
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -5601,7 +5589,7 @@ check-types@^11.1.1:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.1.2.tgz#86a7c12bf5539f6324eb0e70ca8896c0e38f3e2f"
   integrity sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ==
 
-chokidar@2.1.8, chokidar@^2.0.4, chokidar@^2.1.1, chokidar@^2.1.8:
+chokidar@^2.0.4, chokidar@^2.1.1, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -5758,14 +5746,6 @@ cli-truncate@^0.2.1:
   dependencies:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
-
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
 
 cli-width@^3.0.0:
   version "3.0.0"
@@ -6779,26 +6759,6 @@ cypress-cucumber-preprocessor@^2.0.1:
     minimist "^1.2.0"
     through "^2.3.8"
 
-cypress-cucumber-preprocessor@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-4.1.2.tgz#bd653001c2b3441c29685f0699461c38d4c4bd63"
-  integrity sha512-9TPpYeF5VGAO99TWzGnEMIwXamhDvvJP+may/CZKbaEeY8w3Bh82FIGgRiE59OnA92oe/BXJwNrduNgPQ1qt5w==
-  dependencies:
-    "@cypress/browserify-preprocessor" "^3.0.1"
-    chai "^4.2.0"
-    chokidar "2.1.8"
-    cosmiconfig "^4.0.0"
-    cucumber "^4.2.1"
-    cucumber-expressions "^6.0.1"
-    cucumber-tag-expressions "^1.1.1"
-    dargs "^7.0.0"
-    debug "^3.0.1"
-    gherkin "^5.1.0"
-    glob "^7.1.2"
-    js-string-escape "^1.0.1"
-    minimist "^1.2.5"
-    through "^2.3.8"
-
 cypress@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.4.0.tgz#679bfe75335b9a4873d44f0d989e9f0367f00665"
@@ -6831,51 +6791,6 @@ cypress@^7.4.0:
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr "^0.14.3"
-    lodash "^4.17.21"
-    log-symbols "^4.0.0"
-    minimist "^1.2.5"
-    ospath "^1.2.2"
-    pretty-bytes "^5.6.0"
-    ramda "~0.27.1"
-    request-progress "^3.0.0"
-    supports-color "^8.1.1"
-    tmp "~0.2.1"
-    untildify "^4.0.0"
-    url "^0.11.0"
-    yauzl "^2.10.0"
-
-cypress@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.5.0.tgz#72dd342e3b45f54b63cd46819f38d126feff5954"
-  integrity sha512-tw3v6nrTJoEzT37+Nf6RK+DvdTfhMb8EJYskZx7oskZ+J9qQ1QHWA4dH8Eoe/Mr/wE47o+7PK6O9tgqhRy6IHg==
-  dependencies:
-    "@cypress/listr-verbose-renderer" "^0.4.1"
-    "@cypress/request" "^2.88.5"
-    "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
-    "@types/sinonjs__fake-timers" "^6.0.2"
-    "@types/sizzle" "^2.3.2"
-    arch "^2.2.0"
-    blob-util "^2.0.2"
-    bluebird "^3.7.2"
-    cachedir "^2.3.0"
-    chalk "^4.1.0"
-    check-more-types "^2.24.0"
-    cli-table3 "~0.6.0"
-    commander "^5.1.0"
-    common-tags "^1.8.0"
-    dayjs "^1.10.4"
-    debug "4.3.2"
-    eventemitter2 "^6.4.3"
-    execa "4.1.0"
-    executable "^4.1.1"
-    extract-zip "2.0.1"
-    fs-extra "^9.1.0"
-    getos "^3.2.1"
-    is-ci "^3.0.0"
-    is-installed-globally "~0.4.0"
-    lazy-ass "^1.6.0"
-    listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
     minimist "^1.2.5"
@@ -11793,19 +11708,6 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr2@^3.8.3:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.10.0.tgz#58105a53ed7fa1430d1b738c6055ef7bb006160f"
-  integrity sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==
-  dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^1.2.2"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rxjs "^6.6.7"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
-
 listr@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
@@ -12074,16 +11976,6 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
-
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
-  dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
   version "1.7.1"
@@ -13549,11 +13441,6 @@ pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
-
-pathval@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
-  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pause-stream@0.0.11:
   version "0.0.11"
@@ -15582,7 +15469,7 @@ rxjs@^6.3.3, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.6.3, rxjs@^6.6.7:
+rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -15998,15 +15885,6 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
-
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
 
 slice-ansi@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I think these docs cover everything that's required. Writing docs is not something I do often, so please don't hesitate to correct me.

One thing I was wondering about is wether or not we need to add anything under `docs/setups`... The `enableNetworkShim` falls under `setups` too and is currently missing. However, I don't think it's very useful to document this in isolation. The function doesn't even accept any arguments so there is hardly anything to document.

On the other hand, it may be weird that we have two "setups" but only one of them has its own documentation page. Perhaps We just add a file that refers readers to the guide?