### PR TITLE
chore: remove node 10 support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "engines": {
-        "node": ">=10"
+        "node": ">=12"
     },
     "dependencies": {
         "@dhis2/cli-helpers-engine": "^2.3.0",


### PR DESCRIPTION
BREAKING CHANGE: New minimum version for NodeJS is 12.x.