### PR TITLE
fix(network-shim): ensure 304s are dealth with correctly

### DIFF
--- a/packages/cypress-commands/src/setups/enableNetworkShim/captureRequests.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/captureRequests.js
@@ -166,8 +166,9 @@ function processDuplicatedRequest({
         // RequestStub was already nonDeterministic, responseBody is already an array
         const matchingResponseBodyIndex = isNotModified
             ? // When isNotModified the response body is empty and the browser is expected
-              // to return the last known response, so we do the same.
-              requestStub.responseBody.lenght - 1
+              // to return the last known response, so we do the same by returning the 
+              // value of the last responseLookup.
+              requestStub.responseLookup[requestStub.responseLookup.length - 1]
             : requestStub.responseBody.findIndex(
                   responseBody => responseBody === newResponseBody
               )

--- a/packages/cypress-commands/src/setups/enableNetworkShim/captureRequests.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/captureRequests.js
@@ -166,7 +166,7 @@ function processDuplicatedRequest({
         // RequestStub was already nonDeterministic, responseBody is already an array
         const matchingResponseBodyIndex = isNotModified
             ? // When isNotModified the response body is empty and the browser is expected
-              // to return the last known response, so we do the same by returning the 
+              // to return the last known response, so we do the same by returning the
               // value of the last responseLookup.
               requestStub.responseLookup[requestStub.responseLookup.length - 1]
             : requestStub.responseBody.findIndex(

--- a/packages/cypress-commands/src/setups/enableNetworkShim/index.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/index.js
@@ -44,7 +44,7 @@ export function enableNetworkShim() {
             // First get the updated local state from the alias
             cy.get('@networkShimState').then(networkShimState => {
                 /*
-                 * In both capture and stub mode the state needs to be incrementally 
+                 * In both capture and stub mode the state needs to be incrementally
                  * updated across tests, so after every feature the entire plugin state
                  * gets overwritten.
                  */

--- a/packages/cypress-commands/src/setups/enableNetworkShim/index.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/index.js
@@ -44,25 +44,11 @@ export function enableNetworkShim() {
             // First get the updated local state from the alias
             cy.get('@networkShimState').then(networkShimState => {
                 /*
-                 * In capture mode the state needs to be incrementally updated
-                 * across tests, so after every feature the entire plugin state
+                 * In both capture and stub mode the state needs to be incrementally 
+                 * updated across tests, so after every feature the entire plugin state
                  * gets overwritten.
                  */
-                if (isCaptureMode()) {
-                    cy.task('setNetworkShimState', networkShimState)
-                }
-                /*
-                 * In stub mode the state needs to be kept static across features
-                 * apart from the missing request stubs which do need to be
-                 * incrementally updated across features. So in stub mode we only
-                 * update that state property in the plugin.
-                 */
-                if (isStubMode()) {
-                    cy.task(
-                        'setNetworkShimMissingRequestStubs',
-                        networkShimState.missingRequestStubs
-                    )
-                }
+                cy.task('setNetworkShimState', networkShimState)
             })
         }
     })

--- a/packages/cypress-plugins/src/plugins/networkShim/index.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/index.js
@@ -37,12 +37,6 @@ module.exports = function networkShim(
             state = newState
             return state
         },
-        setNetworkShimMissingRequestStubs(missingRequestStubs) {
-            if (Array.isArray(missingRequestStubs)) {
-                state.missingRequestStubs = missingRequestStubs
-            }
-            return state
-        },
     })
 
     on('after:run', results => {


### PR DESCRIPTION
This is a follow-up on #261. I guess the approval app test suite is the first place where we had to deal with repeating requests to the same endpoint that would return a mixture of 304 and 200 responses. In any case, I uncovered 2 bugs. I'll place some comments in the code to explain.

Before merging this in, I think I'd like to check what would happen if we apply these changes in isolation, without the changes from #261. I _think_ both PRs are required, but it could also be possible that the changes in the current PR are actually all that was needed.