### PR TITLE
fix(network shim): wait for network idle after tests

### DIFF
--- a/packages/cypress-commands/src/setups/enableNetworkShim/index.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/index.js
@@ -1,3 +1,4 @@
+import './waitForResources.js'
 import { setDhis2BaseUrlToLocalStorage } from '../../helper/dhis2BaseUrl.js'
 import {
     isLiveMode,
@@ -41,6 +42,8 @@ export function enableNetworkShim() {
 
     afterEach(() => {
         if (!isLiveMode()) {
+            cy.waitForResources()
+
             // First get the updated local state from the alias
             cy.get('@networkShimState').then(networkShimState => {
                 /*

--- a/packages/cypress-commands/src/setups/enableNetworkShim/waitForResources.js
+++ b/packages/cypress-commands/src/setups/enableNetworkShim/waitForResources.js
@@ -1,0 +1,44 @@
+/**
+ * copied and slightly modified from:
+ * https://github.com/cypress-io/cypress/issues/1773#issuecomment-899684192
+ */
+
+let totalRunningQueries = 0
+
+const observer = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) {
+        if (entry.initiatorType === 'fetch') {
+            totalRunningQueries++
+        }
+    }
+})
+
+observer.observe({
+    entryTypes: ['resource'],
+})
+
+Cypress.Commands.add('waitForResources', ({ maxTries = 3 } = {}) => {
+    let tries = 0
+
+    return new Cypress.Promise(resolve => {
+        const check = () => {
+            const requests = window.performance
+                .getEntriesByType('resource')
+                .filter(n => n.initiatorType === 'fetch')
+
+            if (requests.length === totalRunningQueries) {
+                tries++
+                if (tries === maxTries) {
+                    resolve()
+                } else {
+                    setTimeout(check, 100)
+                }
+            } else {
+                tries = 0
+                setTimeout(check, 100)
+            }
+        }
+
+        check()
+    })
+})


### PR DESCRIPTION
Background: Some of our tests were quite flaky. The cause is that some of the requests of the app are being fired when the test is actually done which causes them to not get recorded. When running cypress in stub mode, this produces an error as we're stubbing all requests of a certain url (which applies to requests that run during cypress' internal `after each` hook).

This PR adds a `waitForRequests` command that's being used before storing the captured requests.