### PR TITLE
fix(create fixtures from state): use `replace` instead of `replaceAll`

### DIFF
--- a/packages/cypress-plugins/src/plugins/networkShim/createFixturesFromState.js
+++ b/packages/cypress-plugins/src/plugins/networkShim/createFixturesFromState.js
@@ -24,7 +24,7 @@ module.exports = function createFixturesFromState(state, cypressConfig) {
         (acc, request) => {
             const fileName = request.static
                 ? 'static_resources'
-                : request.featureName.toLowerCase().replaceAll(' ', '_')
+                : request.featureName.toLowerCase().replace(/\s/g, '_')
 
             if (!acc[fileName]) {
                 acc[fileName] = []


### PR DESCRIPTION
replaceAll is supported in nodejs >= v15. Many still use node v12 oder
node v14, so this removes the issue for having to install node v15
just for this function call