### PR TITLE
feat: improve login by api command

### DIFF
--- a/packages/cypress-commands/src/commands/loginByApi.js
+++ b/packages/cypress-commands/src/commands/loginByApi.js
@@ -1,38 +1,57 @@
+/* When the run starts the correct login endpoint is unknown, so an attempt
+ * to login via the api endpoint is tried first and if that fails the
+ * legacy endpoint is queried. Once a successful login has occurred,
+ * the login instructions are stored as a Cypress environment variable
+ * which will persist for the entire run. */
 Cypress.Commands.add('loginByApi', ({ username, password, baseUrl }) => {
-    // Login via API
-    cy.request({
-        url: `${baseUrl}/api/loginConfig`,
-        method: 'GET',
-        followRedirect: false,
-        failOnStatusCode: false,
-    }).then((response) => {
-        // Versions >= 41
-        if (response.status === 200 && response.body['apiVersion']) {
-            cy.request({
-                url: `${baseUrl}/api/auth/login`,
-                method: 'POST',
-                followRedirect: true,
-                body: {
-                    username: username,
-                    password: password,
-                },
-            })
-        } else {
-            // Versions <=40 (302 || 404 )
-            cy.request({
-                url: `${baseUrl}/dhis-web-commons-security/login.action`,
-                method: 'POST',
-                form: true,
-                followRedirect: true,
-                body: {
-                    j_username: username,
-                    j_password: password,
-                    '2fa_code': '',
-                },
-            })
-        }
-    })
+    const HAS_API_AUTH_LOGIN_ENV_KEY = 'hasApiAuthLogin'
+    const hasApiAuthLogin = Cypress.env(HAS_API_AUTH_LOGIN_ENV_KEY)
+    const hasApiAuthLoginUnknown = typeof hasApiAuthLogin !== 'boolean'
+    const apiAuthLoginOptions = {
+        url: `${baseUrl}/api/auth/login`,
+        method: 'POST',
+        followRedirect: !hasApiAuthLoginUnknown,
+        failOnStatusCode: !hasApiAuthLoginUnknown,
+        body: {
+            username: username,
+            password: password,
+        },
+    }
+    const legacyLoginOptions = {
+        url: `${baseUrl}/dhis-web-commons-security/login.action`,
+        method: 'POST',
+        form: true,
+        followRedirect: true,
+        body: {
+            j_username: username,
+            j_password: password,
+            '2fa_code': '',
+        },
+    }
 
     // Set base url for the app platform
     window.localStorage.setItem('DHIS2_BASE_URL', baseUrl)
+
+    if (hasApiAuthLoginUnknown) {
+        return cy.request(apiAuthLoginOptions).then((response) => {
+            if (response.status === 404 || response.status === 302) {
+                return cy.request(legacyLoginOptions).then((legacyResponse) => {
+                    if (legacyResponse.status === 200) {
+                        Cypress.env(HAS_API_AUTH_LOGIN_ENV_KEY, false)
+                        cy.log('Using legacy login endpoint for this test run')
+                    }
+                    return cy.wrap(legacyResponse)
+                })
+            }
+            if (response.status === 200) {
+                Cypress.env(HAS_API_AUTH_LOGIN_ENV_KEY, true)
+                cy.log('Using web API login endpoint for this test run')
+            }
+            return cy.wrap(response)
+        })
+    } else if (hasApiAuthLogin === true) {
+        return cy.request(apiAuthLoginOptions)
+    } else {
+        return cy.request(legacyLoginOptions)
+    }
 })


### PR DESCRIPTION
## Features
- The command no longer relies on a seemingly unrelated endpoint to infer the correct major version of the backend.
- The amount of requests needed to login is also reduced because the correct login mechanism is stored as a Cypress env var, which will remain available for the entire run
- And finally, the command will now always yield a response, which can be asserted, like so:
    ```js
    cy.loginByApiV2({ username, password, baseUrl })
        .its('status')
        .should('equal', 200)
    ```

Some notes:
- We have tried this new login mechanism in one of the analytics-apps. It works fine there, see: https://github.com/dhis2/data-visualizer-app/pull/3388
- But in our analytics apps we have stopped using the `enabledAutoLogin()` helper and we are now using this `cy.loginByApi()` command directly. So perhaps it would be useful to test this out in conjunction with `enableAutoLogin()` before  merging.